### PR TITLE
Update site header to support multiple layouts. 

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -77,7 +77,12 @@ $ const {
       on="newsletter-form-subscription"
       clear-data=true
     />
-    <global-site-header has-user=false reg-enabled=false />
+    <if("navbar2" === site.get("navigation.type"))>
+      <global-site-header-2 has-user=false reg-enabled=false />
+    </if>
+    <else>
+      <global-site-header has-user=false reg-enabled=false />
+    </else>
     <global-site-menu has-user=false reg-enabled=false />
     <!-- <global-site-newsletter-menu /> -->
     <${input.aboveContainer} />

--- a/packages/global/components/marko.json
+++ b/packages/global/components/marko.json
@@ -53,6 +53,9 @@
   "<global-site-header>": {
     "template": "./site-header.marko"
   },
+  "<global-site-header-2>": {
+    "template": "./site-header-2.marko"
+  },
   "<global-site-newsletter-menu>": {
     "template": "./site-newsletter-menu.marko"
   },

--- a/packages/global/components/site-header-2.marko
+++ b/packages/global/components/site-header-2.marko
@@ -1,0 +1,87 @@
+import shuffle from "@ab-media/package-global/utils/shuffle-array";
+import { get, getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
+
+$ const { config, site } = out.global;
+
+$ const blockName = input.blockName || "site-header";
+
+$ const navigation = {
+  primary: site.getAsArray("navigation.primary.items"),
+  secondary: site.getAsArray("navigation.secondary.items"),
+  tertiary: site.getAsArray("navigation.tertiary.items"),
+};
+$ console.log(site.getAsArray("navigation.promos"), shuffle(site.getAsArray("navigation.promos")))
+$ const promo = shuffle(site.getAsArray("navigation.promos"))[0];
+$ const headerColClass = promo ? "col-lg-4" : "col-lg-6";
+
+<marko-web-block
+  name=blockName
+  tag=(input.tag || "header")
+  class=input.class
+  modifiers=input.modifiers
+  attrs=input.attrs
+>
+  <${input.aboveNav} />
+
+  <default-theme-site-navbar modifiers=["top"]>
+    <if(promo)>
+      <div class=`${headerColClass} site-navbar__left`>
+        $ const promoSrc = get(promo, "image.src");
+        $ const promoSrcSet = getAsArray(promo, "image.srcset").join(",");
+        <marko-web-block class="subscribe-box">
+          <if(promoSrc)>
+            <a href=promo.link title=`${promo.callToAction} - ${promo.title}` class="subscribe-box--cover-image">
+              <marko-web-img
+                alt=promo.title
+                src=promoSrc
+                srcset=promoSrcSet
+                lazyload=true
+                class="magazine-cover"
+              />
+            </a>
+          </if>
+          <if(promo.callToAction)>
+            <marko-web-block class="subscribe-box--call-to-action">
+              <a href=promo.link title=`${promo.callToAction} - ${promo.title}` class="btn btn-primary">
+                ${promo.callToAction}
+              </a>
+            </marko-web-block>
+          </if>
+        </marko-web-block>
+      </div>
+    </if>
+    <div class=`${headerColClass} site-navbar__center`>
+      <default-theme-site-navbar-brand title=`${config.website("name")} Homepage`>
+        <default-theme-site-navbar-logo
+          alt=config.website("name")
+          src=site.get("logos.navbar.src")
+          srcset=site.getAsArray("logos.navbar.srcset").join(",")
+        />
+      </default-theme-site-navbar-brand>
+    </div>
+    <div class=`${headerColClass} site-navbar__right`>
+      <marko-web-link href="/search">
+        <button class="btn btn-lg" type="submit" aria-label="Search">
+          <marko-web-icon name="search" modifiers=["dark"] />
+        </button>
+      </marko-web-link>
+      <global-menu-toggle-button
+        class="site-navbar__toggler"
+        targets=[".site-menu", "body"]
+        toggle-class="site-menu--open"
+        icon-modifiers=["lg"]
+        icon-name="three-bars"
+      />
+    </div>
+  </default-theme-site-navbar>
+
+  <default-theme-site-navbar modifiers=["primary"]>
+    <default-theme-site-navbar-items
+      items=navigation.primary
+      modifiers=["primary"]
+      reg-enabled=input.regEnabled
+      has-user=input.hasUser
+    />
+  </default-theme-site-navbar>
+  <${input.belowNav} />
+</marko-web-block>

--- a/packages/global/components/site-header-2.marko
+++ b/packages/global/components/site-header-2.marko
@@ -10,7 +10,6 @@ $ const navigation = {
   secondary: site.getAsArray("navigation.secondary.items"),
   tertiary: site.getAsArray("navigation.tertiary.items"),
 };
-$ console.log(site.getAsArray("navigation.promos"), shuffle(site.getAsArray("navigation.promos")))
 $ const promo = shuffle(site.getAsArray("navigation.promos"))[0];
 $ const headerColClass = promo ? "col-lg-4" : "col-lg-6";
 

--- a/packages/global/scss/_variables.scss
+++ b/packages/global/scss/_variables.scss
@@ -161,12 +161,8 @@ $theme-site-header-breakpoints: map-merge(
 $skin-desktop-menu-breakpoint: map-get($theme-site-header-breakpoints, hide-secondary);
 $theme-site-navbar-brand-margin-x: 36px !default;
 
-@if $navbarStyle == "navbar2" {
-  $theme-site-navbar-logo-height: 60px !default;
-} @else {
-  $theme-site-navbar-logo-height: 46px !default;
-}
-$theme-site-navbar-logo-height-sm: 35px !default;
+$theme-site-navbar-logo-height: 68px;
+$theme-site-navbar-logo-height-sm: 45px;
 
 $theme-site-navbar-primary-height-sm: 0;
 

--- a/packages/global/scss/_variables.scss
+++ b/packages/global/scss/_variables.scss
@@ -143,6 +143,7 @@ $skin-content-primary-image-max-width: 880px;
 $theme-page-title-font-weight: $font-weight-bold;
 
 // Header
+$navbarStyle: "navbar" !default;
 $theme-site-header-box-shadow: none !default;
 $theme-site-header-breakpoints: () !default;
 $theme-site-header-breakpoints: map-merge(
@@ -160,7 +161,11 @@ $theme-site-header-breakpoints: map-merge(
 $skin-desktop-menu-breakpoint: map-get($theme-site-header-breakpoints, hide-secondary);
 $theme-site-navbar-brand-margin-x: 36px !default;
 
-$theme-site-navbar-logo-height: 46px !default;
+@if $navbarStyle == "navbar2" {
+  $theme-site-navbar-logo-height: 60px !default;
+} @else {
+  $theme-site-navbar-logo-height: 46px !default;
+}
 $theme-site-navbar-logo-height-sm: 35px !default;
 
 $theme-site-navbar-primary-height-sm: 0;

--- a/packages/global/scss/components/_site-navbar.scss
+++ b/packages/global/scss/components/_site-navbar.scss
@@ -1,70 +1,72 @@
-.site-navbar {
-  $self: &;
+@if $navbarStyle == "navbar" {
+  .site-navbar {
+    $self: &;
 
-  &__container {
-    max-width: $marko-web-document-container-max-width;
-    @include media-breakpoint-up(xl, $grid-breakpoints) {
+    &__container {
       max-width: $marko-web-document-container-max-width;
-    }
-  }
-
-  &__brand {
-    @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
-      // reduce padding on small logo
-      margin-right: $theme-site-navbar-brand-margin-x / 2;
-      margin-left: $theme-site-navbar-brand-margin-x / 2;
-    }
-  }
-
-  &__logo {
-    filter: none;
-  }
-
-  &__newsletter-toggler {
-    @include theme-toggle-button();
-    padding: 0;
-    margin-top: auto;
-    margin-bottom: auto;
-
-    @media (min-width: map-get($theme-site-header-breakpoints, hide-secondary)) {
-      margin-left: auto;
-    }
-
-    & > .marko-web-icon {
-      @include theme-navbar-link-color($theme-site-navbar-secondary-colors);
-    }
-  }
-
-  &--secondary {
-    #{ $self } {
-      &__container {
-        @media (max-width: map-get($theme-site-header-breakpoints, hide-secondary)) {
-          justify-content: space-between;
-        }
+      @include media-breakpoint-up(xl, $grid-breakpoints) {
+        max-width: $marko-web-document-container-max-width;
       }
     }
-  }
 
-  &__items {
-    text-transform: none;
-
-    &--secondary {
-      @media (max-width: map-get($theme-site-header-breakpoints, hide-secondary)) {
-        display: none;
+    &__brand {
+      @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
+        // reduce padding on small logo
+        margin-right: $theme-site-navbar-brand-margin-x / 2;
+        margin-left: $theme-site-navbar-brand-margin-x / 2;
       }
+    }
+
+    &__logo {
+      filter: none;
+    }
+
+    &__newsletter-toggler {
+      @include theme-toggle-button();
+      padding: 0;
       margin-top: auto;
       margin-bottom: auto;
 
-      // set letter spacing per design
-      letter-spacing: .5px;
+      @media (min-width: map-get($theme-site-header-breakpoints, hide-secondary)) {
+        margin-left: auto;
+      }
 
+      & > .marko-web-icon {
+        @include theme-navbar-link-color($theme-site-navbar-secondary-colors);
+      }
+    }
+
+    &--secondary {
       #{ $self } {
-        &__link {
-          padding-top: 0;
+        &__container {
+          @media (max-width: map-get($theme-site-header-breakpoints, hide-secondary)) {
+            justify-content: space-between;
+          }
+        }
+      }
+    }
 
-          @media (max-width: map-get($theme-site-header-breakpoints, small-text-secondary)) {
-            padding-right: 8px;
-            padding-left: 8px;
+    &__items {
+      text-transform: none;
+
+      &--secondary {
+        @media (max-width: map-get($theme-site-header-breakpoints, hide-secondary)) {
+          display: none;
+        }
+        margin-top: auto;
+        margin-bottom: auto;
+
+        // set letter spacing per design
+        letter-spacing: .5px;
+
+        #{ $self } {
+          &__link {
+            padding-top: 0;
+
+            @media (max-width: map-get($theme-site-header-breakpoints, small-text-secondary)) {
+              padding-right: 8px;
+              padding-left: 8px;
+            }
           }
         }
       }

--- a/packages/global/scss/components/_site-navbar2.scss
+++ b/packages/global/scss/components/_site-navbar2.scss
@@ -1,0 +1,99 @@
+@if $navbarStyle == "navbar2" {
+  .site-navbar {
+    $self: &;
+    &__container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+
+      max-width: $marko-web-document-container-max-width;
+      @include media-breakpoint-up(xl, $grid-breakpoints) {
+        max-width: $marko-web-document-container-max-width;
+      }
+    }
+    &__brand {
+      margin: 0;
+    }
+    &--top {
+      width: 100%;
+      height: 88px;
+      @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
+        height: 58px;
+      }
+      padding-top: 10px;
+      background-color: $white;
+      border-bottom: 1px solid $gray-400;
+      #{ $self } {
+        &__left {
+          padding-left: 0;
+          @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
+            display: none;
+          }
+        }
+        &__center {
+          display: flex;
+          align-self: flex-start;
+          justify-content: center;
+        }
+        &__center.col-lg-6 {
+          justify-content: flex-start;
+          padding-left: 0;
+        }
+        &__right {
+          display: flex;
+          justify-content: flex-end;
+          @media (min-width: map-get($theme-site-header-breakpoints, hide-primary)) {
+            padding-right: 0;
+          }
+          .btn,
+          #{ $self }__toggler {
+            width: 40px;
+            height: 40px;
+            padding: 0;
+            margin: 0 0 0 12px;
+            background-color: $gray-100;
+            border-radius: 4px;
+          }
+        }
+      }
+      .subscribe-box {
+        display: flex;
+        &--cover-image {
+          align-self: flex-end;
+        }
+        &--call-to-action {
+          align-self: center;
+          .btn-primary {
+            padding: 8px;
+            margin-left: 16px;
+            font-size: 12px;
+            text-transform: initial;
+          }
+        }
+      }
+    }
+    &--primary {
+      background-color: $white;
+      #{ $self } {
+        &__link {
+          color: $gray-800;
+          text-transform: initial;
+          &--active {
+            font-weight: 700;
+            text-decoration: none;
+          }
+        }
+        &__items {
+          justify-content: space-between;
+        }
+      }
+      .site-navbar {
+        &__item {
+          flex-grow: unset;
+          padding-right: 0;
+          padding-left: 0;
+        }
+      }
+    }
+  }
+}

--- a/packages/global/scss/components/_site-navbar2.scss
+++ b/packages/global/scss/components/_site-navbar2.scss
@@ -33,7 +33,9 @@
         &__center {
           display: flex;
           align-self: flex-start;
-          justify-content: center;
+          @media (min-width: map-get($theme-site-header-breakpoints, small-logo)) {
+            justify-content: center;
+          }
         }
         &__center.col-lg-6 {
           justify-content: flex-start;

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -23,6 +23,7 @@
 @import "./components/site-footer";
 @import "./components/site-menu";
 @import "./components/site-navbar";
+@import "./components/site-navbar2";
 @import "./components/site-newsletter-menu";
 @import "./components/search-page";
 @import "./components/spec-guide";

--- a/sites/aquamagazine.com/config/navigation.js
+++ b/sites/aquamagazine.com/config/navigation.js
@@ -41,30 +41,6 @@ const desktopMenu = {
 
 module.exports = {
   type: 'navbar2',
-  promos: [
-    {
-      title: 'Aqua Toolbox',
-      callToAction: 'Learn More',
-      image: {
-        src: 'https://img.aquamagazine.com/files/base/abmedia/all/image/static/aqua/Bookpile.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top',
-        srcset: [
-          'https://img.aquamagazine.com/files/base/abmedia/all/image/static/aqua/Bookpile.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70 2x&amp;w=85&amp;crop=top',
-        ],
-      },
-      link: 'https://library.aquamagazine.com/',
-    },
-    {
-      title: 'Buyers Guide',
-      callToAction: 'Read More',
-      image: {
-        src: 'https://img.aquamagazine.com/files/base/abmedia/all/image/static/aqua/geometric15square.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top',
-        srcset: [
-          'https://img.aquamagazine.com/files/base/abmedia/all/image/static/aqua/geometric15square.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70 2x&amp;w=85&amp;crop=top',
-        ],
-      },
-      link: 'https://www.aquamagazine.com/buyers-guide',
-    },
-  ],
   desktopMenu,
   mobileMenu,
   primary: {

--- a/sites/aquamagazine.com/config/navigation.js
+++ b/sites/aquamagazine.com/config/navigation.js
@@ -40,13 +40,38 @@ const desktopMenu = {
 };
 
 module.exports = {
+  type: 'navbar2',
+  promos: [
+    {
+      title: 'Aqua Toolbox',
+      callToAction: 'Learn More',
+      image: {
+        src: 'https://img.aquamagazine.com/files/base/abmedia/all/image/static/aqua/Bookpile.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top',
+        srcset: [
+          'https://img.aquamagazine.com/files/base/abmedia/all/image/static/aqua/Bookpile.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70 2x&amp;w=85&amp;crop=top',
+        ],
+      },
+      link: 'https://library.aquamagazine.com/',
+    },
+    {
+      title: 'Buyers Guide',
+      callToAction: 'Read More',
+      image: {
+        src: 'https://img.aquamagazine.com/files/base/abmedia/all/image/static/aqua/geometric15square.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top',
+        srcset: [
+          'https://img.aquamagazine.com/files/base/abmedia/all/image/static/aqua/geometric15square.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70 2x&amp;w=85&amp;crop=top',
+        ],
+      },
+      link: 'https://www.aquamagazine.com/buyers-guide',
+    },
+  ],
   desktopMenu,
   mobileMenu,
   primary: {
-    items: [],
+    items: topics.primary,
   },
   secondary: {
-    items: topics.primary,
+    items: [],
   },
   tertiary: {
     items: [],

--- a/sites/aquamagazine.com/server/styles/index.scss
+++ b/sites/aquamagazine.com/server/styles/index.scss
@@ -1,5 +1,5 @@
 $theme-site-header-breakpoints: (
-  hide-primary: 100000px, // effectively always hide the primary nav
+  hide-primary: 1200px, // effectively always hide the primary nav
   hide-secondary: 780px,
   small-logo: 980px,
   small-text-primary: 0,
@@ -8,5 +8,8 @@ $theme-site-header-breakpoints: (
 
 // Colors
 $primary: #103a57;
+
+$navbarStyle: "navbar2";
+$theme-site-navbar-primary-type: light;
 
 @import "../../node_modules/@ab-media/package-global/scss/core";

--- a/sites/athleticbusiness.com/config/navigation.js
+++ b/sites/athleticbusiness.com/config/navigation.js
@@ -44,29 +44,41 @@ const desktopMenu = {
 
 module.exports = {
   type: 'navbar2',
+
   promos: [
     {
-      title: 'AB Show 2021 in San Antonio',
-      callToAction: 'Learn More',
+      title: 'AB Magazine',
+      callToAction: 'Subscribe',
       image: {
-        src: 'https://img.athleticbusiness.com/files/base/abmedia/all/image/static/ab/ABshow21_tile100.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top',
+        src: 'https://img.athleticbusiness.com/files/base/abmedia/all/image/static/ab/ab-cover-09-21.jpg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top',
         srcset: [
-          'https://img.athleticbusiness.com/files/base/abmedia/all/image/static/ab/ABshow21_tile100.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70 2x&amp;w=85&amp;crop=top',
+          'https://img.athleticbusiness.com/files/base/abmedia/all/image/static/ab/ab-cover-09-21.jpg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70 2x&amp;w=85&amp;crop=top',
         ],
       },
-      link: 'https://www.abshow.com/',
+      link: 'https://athleticbusiness.dragonforms.com/loading.do?omedasite=ab_land',
     },
-    {
-      title: 'AB Buyers Guide',
-      callToAction: 'Read More',
-      image: {
-        src: 'https://img.athleticbusiness.com/files/base/abmedia/all/image/static/ab/ab-bg-promo.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top',
-        srcset: [
-          'https://img.athleticbusiness.com/files/base/abmedia/all/image/static/ab/ab-bg-promo.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70 2x&amp;w=85&amp;crop=top',
-        ],
-      },
-      link: 'https://www.athleticbusiness.com/buyers-guide',
-    },
+    // {
+    //   title: 'AB Show 2021 in San Antonio',
+    //   callToAction: 'Learn More',
+    //   image: {
+    //     src: 'https://img.athleticbusiness.com/files/base/abmedia/all/image/static/ab/ABshow21_tile100.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top',
+    //     srcset: [
+    //       'https://img.athleticbusiness.com/files/base/abmedia/all/image/static/ab/ABshow21_tile100.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70 2x&amp;w=85&amp;crop=top',
+    //     ],
+    //   },
+    //   link: 'https://www.abshow.com/',
+    // },
+    // {
+    //   title: 'AB Buyers Guide',
+    //   callToAction: 'Read More',
+    //   image: {
+    //     src: 'https://img.athleticbusiness.com/files/base/abmedia/all/image/static/ab/ab-bg-promo.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top',
+    //     srcset: [
+    //       'https://img.athleticbusiness.com/files/base/abmedia/all/image/static/ab/ab-bg-promo.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70 2x&amp;w=85&amp;crop=top',
+    //     ],
+    //   },
+    //   link: 'https://www.athleticbusiness.com/buyers-guide',
+    // },
   ],
   desktopMenu,
   mobileMenu,

--- a/sites/athleticbusiness.com/config/navigation.js
+++ b/sites/athleticbusiness.com/config/navigation.js
@@ -43,16 +43,41 @@ const desktopMenu = {
 };
 
 module.exports = {
+  type: 'navbar2',
+  promos: [
+    {
+      title: 'AB Show 2021 in San Antonio',
+      callToAction: 'Learn More',
+      image: {
+        src: 'https://img.athleticbusiness.com/files/base/abmedia/all/image/static/ab/ABshow21_tile100.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top',
+        srcset: [
+          'https://img.athleticbusiness.com/files/base/abmedia/all/image/static/ab/ABshow21_tile100.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70 2x&amp;w=85&amp;crop=top',
+        ],
+      },
+      link: 'https://www.abshow.com/',
+    },
+    {
+      title: 'AB Buyers Guide',
+      callToAction: 'Read More',
+      image: {
+        src: 'https://img.athleticbusiness.com/files/base/abmedia/all/image/static/ab/ab-bg-promo.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top',
+        srcset: [
+          'https://img.athleticbusiness.com/files/base/abmedia/all/image/static/ab/ab-bg-promo.jpeg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70 2x&amp;w=85&amp;crop=top',
+        ],
+      },
+      link: 'https://www.athleticbusiness.com/buyers-guide',
+    },
+  ],
   desktopMenu,
   mobileMenu,
   primary: {
-    items: [],
-  },
-  secondary: {
     items: [
       ...topics.primary,
       { href: 'https://www.abshow.com', label: 'AB Show', target: '_blank' },
     ],
+  },
+  secondary: {
+    items: [],
   },
   tertiary: {
     items: [],

--- a/sites/athleticbusiness.com/server/styles/index.scss
+++ b/sites/athleticbusiness.com/server/styles/index.scss
@@ -1,5 +1,5 @@
 $theme-site-header-breakpoints: (
-  hide-primary: 100000px, // effectively always hide the primary nav
+  hide-primary: 1200px, // effectively always hide the primary nav
   hide-secondary: 780px,
   small-logo: 980px,
   small-text-primary: 0,
@@ -8,5 +8,8 @@ $theme-site-header-breakpoints: (
 
 // Colors
 $primary: #103a57;
+
+$navbarStyle: "navbar2";
+$theme-site-navbar-primary-type: light;
 
 @import "../../node_modules/@ab-media/package-global/scss/core";

--- a/sites/woodfloorbusiness.com/config/navigation.js
+++ b/sites/woodfloorbusiness.com/config/navigation.js
@@ -41,19 +41,6 @@ const desktopMenu = {
 
 module.exports = {
   type: 'navbar2',
-  promos: [
-    {
-      title: 'Wood Floor Business Magazine',
-      callToAction: 'Subscribe',
-      image: {
-        src: 'https://img.woodfloorbusiness.com/files/base/abmedia/all/image/static/wfb/wfb-toolbox-homepage.jpg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top',
-        srcset: [
-          'https://img.woodfloorbusiness.com/files/base/abmedia/all/image/static/wfb/wfb-toolbox-homepage.jpg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70 2x&amp;w=85&amp;crop=top',
-        ],
-      },
-      link: 'https://toolbox.woodfloorbusiness.com/',
-    },
-  ],
   desktopMenu,
   mobileMenu,
   primary: {

--- a/sites/woodfloorbusiness.com/config/navigation.js
+++ b/sites/woodfloorbusiness.com/config/navigation.js
@@ -40,13 +40,27 @@ const desktopMenu = {
 };
 
 module.exports = {
+  type: 'navbar2',
+  promos: [
+    {
+      title: 'Wood Floor Business Magazine',
+      callToAction: 'Subscribe',
+      image: {
+        src: 'https://img.woodfloorbusiness.com/files/base/abmedia/all/image/static/wfb/wfb-toolbox-homepage.jpg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top',
+        srcset: [
+          'https://img.woodfloorbusiness.com/files/base/abmedia/all/image/static/wfb/wfb-toolbox-homepage.jpg?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70 2x&amp;w=85&amp;crop=top',
+        ],
+      },
+      link: 'https://toolbox.woodfloorbusiness.com/',
+    },
+  ],
   desktopMenu,
   mobileMenu,
   primary: {
-    items: [],
+    items: topics.primary,
   },
   secondary: {
-    items: topics.primary,
+    items: [],
   },
   tertiary: {
     items: [],

--- a/sites/woodfloorbusiness.com/server/styles/index.scss
+++ b/sites/woodfloorbusiness.com/server/styles/index.scss
@@ -1,5 +1,5 @@
 $theme-site-header-breakpoints: (
-  hide-primary: 100000px, // effectively always hide the primary nav
+  hide-primary: 1200px, // effectively always hide the primary nav
   hide-secondary: 780px,
   small-logo: 980px,
   small-text-primary: 0,
@@ -8,5 +8,8 @@ $theme-site-header-breakpoints: (
 
 // Colors
 $primary: #103a57;
+
+$navbarStyle: "navbar2";
+$theme-site-navbar-primary-type: light;
 
 @import "../../node_modules/@ab-media/package-global/scss/core";


### PR DESCRIPTION
**TRELLO:** https://trello.com/c/bZEayML9/77-update-header-to-new-version

Add the ability to switch between multiple headers, currently only 2 & might remove to make a single standard layout.  

The navigation type needs to be set within the navigation config and the site css for this to work correctly.  At minimum you will need to ad `type: 'navbar2',` to the navigation config & the following needs to be done in the index.scss file within the site folder: 
 - update: `hide-primary: 1200px,`
 - Add: `$navbarStyle: "navbar2";`
 - Add: `$theme-site-navbar-primary-type: light;`

Additionally I add the ability to add navigation promos within the navigation config.  An example can be found within the ab navigation.js config.  If there are none the logo will move to the left side of the screen instead of being centered.  
<img width="1349" alt="Screen Shot 2021-09-13 at 12 47 47 PM" src="https://user-images.githubusercontent.com/3845869/133131998-5270623b-cecb-4ab5-a587-1ba369abaee1.png">

<img width="1210" alt="Screen Shot 2021-09-13 at 12 47 40 PM" src="https://user-images.githubusercontent.com/3845869/133132080-6ed21a9a-f363-4df2-a3d4-c6077437754b.png">


<img width="1254" alt="Screen Shot 2021-09-13 at 10 26 26 AM" src="https://user-images.githubusercontent.com/3845869/133113734-5db558f4-c3a1-4e1a-bbb8-dc2fb9afacc3.png">
