### PR TITLE
Add magazine routes, templates, components & styles

### DIFF
--- a/packages/global/components/magazine/blocks/magazine-current-issue.marko
+++ b/packages/global/components/magazine/blocks/magazine-current-issue.marko
@@ -1,0 +1,37 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import latestIssueFragment from "../graphql/fragments/magazine-latest-issue";
+
+$ const { publicationId } = input;
+
+<marko-web-query|{ node: issue }|
+  name="magazine-latest-issue"
+  params={ publicationId, queryFragment: latestIssueFragment, requiresImage: true  }
+>
+  <marko-web-node-list
+    inner-justified=true
+    flush-x=true
+    flush-y=true
+    modifiers=[
+      "latest-issue",
+    ]
+    header=input.header
+    footer=input.footer
+  >
+    <@header>
+      <marko-web-magazine-issue-name tag=null obj=issue link=true>
+        In Print
+      </marko-web-magazine-issue-name>
+    </@header>
+    <@nodes nodes=[issue]>
+      <@slot|{ node: issue }| position="at" index=0>
+        <global-magazine-latest-issue-node node=issue />
+      </@slot>
+    </@nodes>
+    <@footer>
+      <global-magazine-publication-buttons
+        issue=issue
+        buttons=['subscribe', 'digital-edition', 'archives']
+      />
+    </@footer>
+  </marko-web-node-list>
+</marko-web-query>

--- a/packages/global/components/magazine/blocks/magazine-issue-cards.marko
+++ b/packages/global/components/magazine/blocks/magazine-issue-cards.marko
@@ -1,0 +1,33 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import queryFragment from "../graphql/fragments/section-feed-block";
+
+$ const queryParams = {
+  ...input.queryParams,
+  sectionAlias: input.alias,
+  queryFragment,
+};
+
+$ const blockName = "section-feed";
+$ const countOnly = defaultValue(input.countOnly, false);
+
+<if(countOnly)>
+  <global-query-total-count|data| name="website-scheduled-content" params=queryParams>
+    <${input.renderBody} ...data />
+  </global-query-total-count>
+</if>
+<else>
+  <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
+    <marko-web-node-list
+      inner-justified=true
+      flush-x=true
+      flush-y=false
+      modifiers=[blockName]
+    >
+      <@nodes nodes=nodes>
+        <@slot|{ node }|>
+          <global-section-feed-content-node node=node />
+        </@slot>
+      </@nodes>
+    </marko-web-node-list>
+  </marko-web-query>
+</else>

--- a/packages/global/components/magazine/blocks/magazine-issues.marko
+++ b/packages/global/components/magazine/blocks/magazine-issues.marko
@@ -1,0 +1,43 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import queryFragment from "../graphql/fragments/magazine-latest-issue";
+
+$ const { site } = out.global;
+$ const { publicationId } = input;
+$ const blockName = "magazine-issues"
+
+<marko-web-query|{ nodes }| name="magazine-active-issues"
+  params={
+    publicationId,
+    queryFragment,
+    limit: 4,
+    requiresCoverImage: true
+  }
+>
+  <marko-web-block name=blockName>
+    <marko-web-element block-name=blockName name="wrapper">
+      <marko-web-element block-name=blockName name="contents">
+        <marko-web-element block-name=blockName name="header">
+          In Print
+        </marko-web-element>
+        <global-magazine-issue-archive-flow nodes=nodes with-title=input.withTitle flush=true />
+      </marko-web-element>
+    </marko-web-element>
+    <marko-web-element block-name=blockName name="wrapper">
+      <marko-web-element block-name=blockName name="contents" modifiers=["buttons"]>
+        <marko-web-magazine-publication-subscribe-url
+          tag=null
+          obj=nodes[0].publication
+          link={
+            class: "btn btn-primary",
+            target: "_blank",
+          }
+        >
+          Subscribe
+        </marko-web-magazine-publication-subscribe-url>
+        <marko-web-link href=`/magazine/${publicationId}` class="btn btn-secondary" >
+          Archives
+        </marko-web-link>
+      </marko-web-element>
+    </marko-web-element>
+  </marko-web-block>
+</marko-web-query>

--- a/packages/global/components/magazine/blocks/magazine-publications.marko
+++ b/packages/global/components/magazine/blocks/magazine-publications.marko
@@ -1,0 +1,13 @@
+import publicationListFragment from "../graphql/fragments/magazine-publication-list";
+
+<marko-web-query|{ nodes }| name="magazine-publications" params={ queryFragmet: publicationListFragment }>
+  <for|publication| of=nodes>
+    <marko-web-query|{ node: latestIssue }| name="magazine-latest-issue" params={ publicationId: publication.id }>
+      <default-theme-magazine-publication-card-block publication-id=publication.id issue-id=latestIssue.id>
+        <@header>
+          <marko-web-magazine-publication-name tag=null obj=publication link=true />
+        </@header>
+      </default-theme-magazine-publication-card-block>
+    </marko-web-query>
+  </for>
+</marko-web-query>

--- a/packages/global/components/magazine/blocks/magazine-publications.marko
+++ b/packages/global/components/magazine/blocks/magazine-publications.marko
@@ -1,6 +1,10 @@
 import publicationListFragment from "../graphql/fragments/magazine-publication-list";
+import { getAsArray } from "@parameter1/base-cms-object-path";
 
-<marko-web-query|{ nodes }| name="magazine-publications" params={ queryFragmet: publicationListFragment }>
+$ const { site } = out.global;
+$ const publicationIds = site.getAsArray("publicationIds");
+
+<marko-web-query|{ nodes }| name="magazine-publications" params={ publicationIds: publicationIds, queryFragmet: publicationListFragment }>
   <for|publication| of=nodes>
     <marko-web-query|{ node: latestIssue }| name="magazine-latest-issue" params={ publicationId: publication.id }>
       <default-theme-magazine-publication-card-block publication-id=publication.id issue-id=latestIssue.id>

--- a/packages/global/components/magazine/blocks/marko.json
+++ b/packages/global/components/magazine/blocks/marko.json
@@ -1,0 +1,14 @@
+{
+  "<global-magazine-current-issue-block>": {
+    "template": "./magazine-current-issue.marko"
+  },
+  "<global-magazine-publications-block>": {
+    "template": "./magazine-publications.marko"
+  },
+  "<global-magazine-issues-block>": {
+    "template": "./magazine-issues.marko"
+  },
+  "<global-magazine-issue-cards-block>": {
+    "template": "./magazine-issue-cards.marko"
+  }
+}

--- a/packages/global/components/magazine/flows/magazine-issue-archive.marko
+++ b/packages/global/components/magazine/flows/magazine-issue-archive.marko
@@ -1,0 +1,12 @@
+import { getAsArray } from "@parameter1/base-cms-object-path";
+
+$ const { aliases } = input;
+$ const nodes = getAsArray(input, "nodes");
+
+<if(nodes.length)>
+  <default-theme-card-deck-flow nodes=nodes modifiers=input.modifiers cols=4>
+    <@slot|{ node }|>
+      <global-magazine-issue-archive-node node=node flush=input.flush with-title=input.withTitle />
+    </@slot>
+  </default-theme-card-deck-flow>
+</if>

--- a/packages/global/components/magazine/flows/magazine-latest-issue.marko
+++ b/packages/global/components/magazine/flows/magazine-latest-issue.marko
@@ -1,0 +1,22 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+
+$ const nodes = [];
+$ const issueNode = getAsObject(input, "issueNode");
+$ if (issueNode) nodes.push(issueNode);
+
+<marko-web-node-list
+  inner-justified=true
+  flush-x=true
+  flush-y=true
+  modifiers=[
+    "latest-issue",
+  ]
+  header=input.header
+  footer=input.footer
+>
+  <@nodes nodes=nodes>
+    <@slot|{ node: issue }| position="at" index=0>
+      <global-magazine-latest-issue-node node=issue />
+    </@slot>
+  </@nodes>
+</marko-web-node-list>

--- a/packages/global/components/magazine/flows/marko.json
+++ b/packages/global/components/magazine/flows/marko.json
@@ -1,0 +1,21 @@
+{
+  "<global-magazine-issue-archive-flow>": {
+    "template": "./magazine-issue-archive.marko",
+    "@nodes": "array",
+    "@flush": {
+      "type": "boolean",
+      "default-value": false
+    },
+    "@with-title": {
+      "type": "boolean",
+      "default-value": true
+    },
+    "@modifiers": "array"
+  },
+  "<global-magazine-latest-issue-flow>": {
+    "template": "./magazine-latest-issue.marko",
+    "<header>": {},
+    "<footer>": {},
+    "@issue-node": "object"
+  }
+}

--- a/packages/global/components/magazine/graphql/fragments/magazine-issue-archive.js
+++ b/packages/global/components/magazine/graphql/fragments/magazine-issue-archive.js
@@ -1,0 +1,19 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment MagazineIssueArchiveFragment on MagazineIssue {
+  id
+  name
+  canonicalPath
+  coverImage {
+    id
+    src(input: { options: { auto: "format,compress", q: 70 } })
+  }
+  publication {
+    id
+    name
+  }
+}
+
+`;

--- a/packages/global/components/magazine/graphql/fragments/magazine-issue-page.js
+++ b/packages/global/components/magazine/graphql/fragments/magazine-issue-page.js
@@ -1,0 +1,23 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment MagazineIssuePageFragment on MagazineIssue {
+  id
+  name
+  description
+  digitalEditionUrl
+  canonicalPath
+  coverImage {
+    id
+    src(input: { options: { auto: "format,compress", q: 70 } })
+  }
+  publication {
+    id
+    name
+    subscribeUrl
+    canonicalPath
+  }
+}
+
+`;

--- a/packages/global/components/magazine/graphql/fragments/magazine-latest-issue.js
+++ b/packages/global/components/magazine/graphql/fragments/magazine-latest-issue.js
@@ -1,0 +1,22 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment MagazineCurrentIssueFragment on MagazineIssue {
+  id
+  name
+  digitalEditionUrl
+  canonicalPath
+  coverImage {
+    id
+    src(input: { options: { auto: "format,compress", q: 70 } })
+  }
+  publication {
+    id
+    name
+    subscribeUrl
+    canonicalPath
+  }
+}
+
+`;

--- a/packages/global/components/magazine/graphql/fragments/magazine-publication-list.js
+++ b/packages/global/components/magazine/graphql/fragments/magazine-publication-list.js
@@ -1,0 +1,11 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment MagazinePublicationListFragment on MagazinePublication {
+  id
+  name
+  canonicalPath
+}
+
+`;

--- a/packages/global/components/magazine/graphql/fragments/magazine-publication-page.js
+++ b/packages/global/components/magazine/graphql/fragments/magazine-publication-page.js
@@ -1,0 +1,12 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment MagazinePublicationPageFragment on MagazinePublication {
+  id
+  name
+  description
+  canonicalPath
+}
+
+`;

--- a/packages/global/components/magazine/marko.json
+++ b/packages/global/components/magazine/marko.json
@@ -1,0 +1,10 @@
+{
+  "taglib-imports": [
+    "./blocks/marko.json",
+    "./flows/marko.json",
+    "./nodes/marko.json"
+  ],
+  "<global-magazine-publication-buttons>": {
+    "template": "./publication-buttons.marko"
+  }
+}

--- a/packages/global/components/magazine/nodes/magazine-issue-archive.marko
+++ b/packages/global/components/magazine/nodes/magazine-issue-archive.marko
@@ -1,0 +1,28 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import { defaultValue } from "@parameter1/base-cms-marko-web/utils";
+
+$ const issue = getAsObject(input, "node");
+$ const publication = getAsObject(issue, "publication");
+$ const coverImage = getAsObject(issue, "coverImage");
+$ const alt = `${publication.name} ${issue.name}`;
+
+<marko-web-node
+  image-position="top"
+  card=defaultValue(input.card, true)
+  flush=defaultValue(input.flush, false)
+  full-height=defaultValue(input.fullHeight, false)
+>
+  <@image
+    src=coverImage.src
+    alt=(coverImage.alt || alt)
+    fluid=true
+    ar="3:4"
+    width=defaultValue(input.imageWidth, 400)
+    link={ href: issue.canonicalPath, title: alt }
+  />
+  <@body>
+    <@title tag="h5" show=defaultValue(input.withTitle, true)>
+      <marko-web-magazine-issue-name tag=null obj=issue link={ title: alt } />
+    </@title>
+  </@body>
+</marko-web-node>

--- a/packages/global/components/magazine/nodes/magazine-latest-issue.marko
+++ b/packages/global/components/magazine/nodes/magazine-latest-issue.marko
@@ -1,0 +1,32 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import { defaultValue } from "@parameter1/base-cms-marko-web/utils";
+
+$ const issue = getAsObject(input, "node");
+$ const publication = getAsObject(issue, "publication");
+$ const coverImage = getAsObject(issue, "coverImage");
+$ const linkTitle = `${publication.name} ${issue.name}`;
+
+<marko-web-node
+  image-position="top"
+  card=defaultValue(input.card, false)
+  flush=defaultValue(input.flush, true)
+>
+  <@image
+    src=coverImage.src
+    alt=(coverImage.alt || linkTitle)
+    fluid=true
+    ar="3:4"
+    width=(input.imageWidth || 300)
+    link={ href: issue.canonicalPath, title: linkTitle }
+  />
+  <@body>
+    <@title tag="h5">
+      <marko-web-magazine-issue-name tag=null obj=issue link={ title: linkTitle } />
+    </@title>
+    <!-- <@footer>
+      <@left>
+        <global-magazine-publication-buttons publication=publication issue=issue />
+      </@left>
+    </@footer> -->
+  </@body>
+</marko-web-node>

--- a/packages/global/components/magazine/nodes/marko.json
+++ b/packages/global/components/magazine/nodes/marko.json
@@ -1,0 +1,21 @@
+{
+  "<global-magazine-latest-issue-node>": {
+    "template": "./magazine-latest-issue.marko",
+    "@node": "object",
+    "@flush": "boolean",
+    "@card": "boolean",
+    "@image-width": {
+      "type": "number",
+      "default-value": 300
+    }
+  },
+  "<global-magazine-issue-archive-node>": {
+    "template": "./magazine-issue-archive.marko",
+    "@node": "object",
+    "@image-width": "number",
+    "@full-height": "boolean",
+    "@flush": "boolean",
+    "@card": "boolean",
+    "@with-title": "boolean"
+  }
+}

--- a/packages/global/components/magazine/publication-buttons.marko
+++ b/packages/global/components/magazine/publication-buttons.marko
@@ -1,0 +1,47 @@
+import { getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const link = { class: "btn btn-primary" };
+$ const targetBlankLink = {
+  ...link,
+  target: "_blank"
+};
+
+$ const issue = getAsObject(input, "issue");
+$ const buttons = defaultValue(input.buttons, ["subscribe", "digital-edition", "pdf", "archives", "renewal", "reprints", "e-inquiry"]);
+
+<if(buttons.includes("subscribe"))>
+  <marko-web-magazine-publication-subscribe-url tag=null obj=issue.publication link=targetBlankLink>
+    Subscribe
+  </marko-web-magazine-publication-subscribe-url>
+</if>
+<if(buttons.includes("digital-edition"))>
+  <marko-web-magazine-issue-digital-edition-url tag=null obj=issue link=targetBlankLink>
+    Digital Edition
+  </marko-web-magazine-issue-digital-edition-url>
+</if>
+<if(buttons.includes("pdf"))>
+  <marko-web-magazine-issue-pdf-url tag=null obj=issue link=targetBlankLink>
+    Download PDF
+  </marko-web-magazine-issue-pdf-url>
+</if>
+<if(buttons.includes("archives"))>
+  <marko-web-magazine-publication-name tag=null obj=issue.publication link=link>
+    Archives
+  </marko-web-magazine-publication-name>
+</if>
+<if(buttons.includes("renewal"))>
+  <marko-web-magazine-publication-renewal-url tag=null obj=issue.publication link=targetBlankLink>
+    Renewal
+  </marko-web-magazine-publication-renewal-url>
+</if>
+<if(buttons.includes("reprints"))>
+  <marko-web-magazine-publication-reprints-url tag=null obj=issue.publication link=targetBlankLink>
+    Reprints
+  </marko-web-magazine-publication-reprints-url>
+</if>
+<if(buttons.includes("e-inquiry"))>
+  <marko-web-magazine-publication-einquiry-url tag=null obj=issue.publication link=targetBlankLink>
+    E-Inquiry
+  </marko-web-magazine-publication-einquiry-url>
+</if>

--- a/packages/global/components/magazine/routes/index.js
+++ b/packages/global/components/magazine/routes/index.js
@@ -1,0 +1,22 @@
+const { withMagazineIssue, withMagazinePublication } = require('@parameter1/base-cms-marko-web/middleware');
+const index = require('../templates/index');
+const publication = require('../templates/publication');
+const publicationFragment = require('../graphql/fragments/magazine-publication-page');
+const issue = require('../templates/issue');
+const issueFragment = require('../graphql/fragments/magazine-issue-page');
+
+module.exports = (app) => {
+  app.get('/magazine', (req, res) => {
+    res.marko(index);
+  });
+
+  app.get('/magazine/:id([a-fA-F0-9]{24})', withMagazinePublication({
+    template: publication,
+    queryFragment: publicationFragment,
+  }));
+
+  app.get('/magazine/:id(\\d+)', withMagazineIssue({
+    template: issue,
+    queryFragment: issueFragment,
+  }));
+};

--- a/packages/global/components/magazine/scss/index.scss
+++ b/packages/global/components/magazine/scss/index.scss
@@ -1,0 +1,92 @@
+.magazine-publication-buttons {
+  $self: &;
+  display: flex;
+  #{ $self }__button {
+    padding: 12px;
+    font-size: 12px;
+    white-space: nowrap;
+  }
+}
+
+.magazine-publication-card-block {
+  &__header {
+    padding-right: 0;
+    padding-left: 0;
+  }
+  &__body {
+    padding-right: 0;
+    padding-left: 0;
+    .issue-archive-cover {
+      margin-bottom: $block-spacer;
+    }
+  }
+}
+.page {
+  &--magazine-publication {
+    .page-wrapper {
+      &__title {
+        @include skin-typography($style: "section-header");
+      }
+    }
+  }
+  &--magazine-issue {
+    .magazine-publication-card-block {
+      &__body {
+        padding-right: 10px;
+        padding-left: 10px;
+      }
+      .node {
+        &__title {
+          @include skin-typography($style: "section-header");
+          text-transform: none;
+        }
+        &__footer-left {
+          display: flex;
+          justify-content: space-between;
+          @include marko-web-node-list-border(border-top);
+          width: 100%;
+          padding-top: 1rem;
+          font-weight: $font-weight-bold;
+          .btn {
+            padding: 12px;
+            font-size: 12px;
+          }
+        }
+      }
+    }
+  }
+}
+.node-list {
+  $self: &;
+  &--latest-issue {
+    #{ $self }__header {
+      @include skin-typography($style: "section-header-small", $link-style: "primary");
+      margin-bottom: 1rem;
+    }
+    #{ $self }__nodes {
+      padding-top: 10px;
+    }
+    #{ $self }__footer {
+      display: flex;
+      justify-content: space-between;
+      @include marko-web-node-list-border(border-top);
+      padding-bottom: map-get($spacers, "block");
+      font-weight: $font-weight-bold;
+    }
+    .btn  {
+      padding: 12px;
+      font-size: 12px;
+    }
+    .node-list {
+      &__node:first-child {
+        @include marko-web-node-list-border(border-top);
+        padding-top: 1rem;
+      }
+      &__nodes {
+        flex-grow: 0;
+        padding-top: 0;
+        border-bottom: none;
+      }
+    }
+  }
+}

--- a/packages/global/components/magazine/templates/index.marko
+++ b/packages/global/components/magazine/templates/index.marko
@@ -1,0 +1,39 @@
+$ const { site } = out.global;
+
+$ const type = "magazines";
+$ const title = "Magazines";
+$ const description = site.get("magazines.description");
+
+<marko-web-default-page-layout type=type title=title description=description>
+  <@head>
+    <marko-web-gtm-default-context|{ context }| type=type>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-default-context>
+  </@head>
+  <@page>
+    <marko-web-page-wrapper class="mb-block">
+      <@section|{ aliases }|>
+        <global-gam-define-display-ad
+          name="rotation"
+          position="magazine_page"
+          aliases=aliases
+          modifiers=["inter-block"]
+        />
+      </@section>
+
+      <@section>
+        <div class="row">
+          <div class="col">
+            <h1 class="page-wrapper__title">${title}</h1>
+            <if(description)>
+              <p class="page-wrapper__deck">${description}</p>
+            </if>
+          </div>
+        </div>
+      </@section>
+      <@section>
+        <global-magazine-publications-block />
+      </@section>
+    </marko-web-page-wrapper>
+  </@page>
+</marko-web-default-page-layout>

--- a/packages/global/components/magazine/templates/issue.marko
+++ b/packages/global/components/magazine/templates/issue.marko
@@ -1,0 +1,102 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import issueFragment from "../graphql/fragments/magazine-issue-archive";
+
+$ const { site } = out.global;
+$ const { id, pageNode } = data;
+
+<marko-web-magazine-issue-page-layout id=id>
+  <@head>
+    <marko-web-gtm-magazine-issue-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-magazine-issue-context>
+  </@head>
+  <@page>
+    <marko-web-page-wrapper class="mb-block">
+      <@section|{ aliases }|>
+        <global-gam-define-display-ad
+          name="rotation"
+          position="magazine_page"
+          aliases=aliases
+          modifiers=["inter-block"]
+        />
+      </@section>
+
+      <@section>
+        <div class="row">
+          <div class="col">
+            <marko-web-resolve-page|{ data: issue }| node=pageNode>
+              <default-theme-breadcrumbs modifiers=["website-section"]>
+                <@item><marko-web-link href="/magazine">Magazine</marko-web-link></@item>
+                <@item><marko-web-magazine-publication-name tag=null obj=issue.publication link=true /></@item>
+              </default-theme-breadcrumbs>
+              <div class="magazine-publication-card-block">
+                <div class="magazine-publication-card-block__body">
+                  <div class="row">
+                    <div class="col-lg-8 pl-0">
+                      <marko-web-node image-position="left" modifiers=["flush"] flush=false>
+                        <@image
+                          src=issue.coverImage.src
+                          alt=(issue.coverImage.alt || issue.name)
+                          fluid=false
+                          ar="3:4"
+                          width=300
+                          link={ href: issue.canonicalPath, title: issue.name }
+                        />
+                        <@body>
+                          <@title tag="h1">
+                            <marko-web-magazine-issue-name tag=null obj=issue />
+                          </@title>
+                          <@text modifiers=["teaser"]>
+                            <marko-web-magazine-issue-description tag=null obj=issue />
+                          </@text>
+                          <@footer>
+                            <@left>
+                              <global-magazine-publication-buttons issue=issue />
+                            </@left>
+                          </@footer>
+                        </@body>
+                      </marko-web-node>
+                    </div>
+                    <marko-web-query|{ nodes: issues }| name="magazine-active-issues"
+                      params={
+                        publicationId: issue.publication.id,
+                        excludeIssueIds: [issue.id],
+                        queryFragment: issueFragment,
+                        limit: 9,
+                        requiresCoverImage: true
+                      }
+                    >
+                      <div class="col-lg-4">
+                        <div class="row">
+                          <for|issue| of=issues>
+                            <div class="col-4 issue-archive-cover">
+                              <marko-web-node
+                                image-position="top"
+                                card=true
+                                flush=true
+                                full-height=true
+                              >
+                                <@image
+                                  src=issue.coverImage.src
+                                  alt=(issue.coverImage.alt || issue.name)
+                                  fluid=true
+                                  ar="3:4"
+                                  width=190
+                                  link={ href: issue.canonicalPath, title: issue.name }
+                                />
+                              </marko-web-node>
+                            </div>
+                          </for>
+                        </div>
+                      </div>
+                    </marko-web-query>
+                  </div>
+                </div>
+              </div>
+            </marko-web-resolve-page>
+          </div>
+        </div>
+      </@section>
+    </marko-web-page-wrapper>
+  </@page>
+</marko-web-magazine-issue-page-layout>

--- a/packages/global/components/magazine/templates/publication.marko
+++ b/packages/global/components/magazine/templates/publication.marko
@@ -1,0 +1,69 @@
+import issueFragment from "../graphql/fragments/magazine-issue-archive";
+
+$ const { pagination: p, req } = out.global;
+$ const { id, pageNode } = data;
+$ const perPage = 16;
+
+<marko-web-magazine-publication-page-layout id=id>
+  <@head>
+    <marko-web-gtm-magazine-publication-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-magazine-publication-context>
+  </@head>
+  <@page>
+    <marko-web-page-wrapper>
+      <@section|{ aliases }|>
+        <global-gam-define-display-ad
+          name="rotation"
+          position="magazine_page"
+          aliases=aliases
+          modifiers=["inter-block"]
+        />
+      </@section>
+
+      <@section>
+        <div class="row">
+          <div class="col">
+              <default-theme-breadcrumbs modifiers=["website-section"]>
+                <@item><marko-web-link href="/magazine">Magazine</marko-web-link></@item>
+              </default-theme-breadcrumbs>
+            <marko-web-resolve-page|{ data: publication }| node=pageNode>
+              <h1 class="page-wrapper__title">
+                ${publication.name} Issue Archive
+                <if(p.page > 1)>: Page ${p.page}</if>
+              </h1>
+              <if(publication.description)>
+                <p class="page-wrapper__deck">${publication.description}</p>
+              </if>
+            </marko-web-resolve-page>
+          </div>
+        </div>
+      </@section>
+      <@section>
+        <marko-web-resolve-page|{ data: publication }| node=pageNode>
+          $ const params = {
+            publicationId: id,
+            limit: perPage,
+            skip:p.skip({ perPage }),
+            queryFragment: issueFragment,
+          };
+          <marko-web-query|{ nodes }|
+            name="magazine-active-issues"
+            params=params
+          >
+            <global-magazine-issue-archive-flow nodes=nodes flush=true />
+          </marko-web-query>
+          <div class="mb-block">
+            <global-query-total-count|{ totalCount }| name="magazine-active-issues" params={publicationId: id}>
+              <global-pagination-controls
+                per-page=perPage
+                total-count=totalCount
+                path=req.path
+              />
+            </global-query-total-count>
+          </div>
+        </marko-web-resolve-page>
+      </@section>
+    </marko-web-page-wrapper>
+  </@page>
+</marko-web-magazine-publication-page-layout>

--- a/packages/global/components/query-total-count.marko
+++ b/packages/global/components/query-total-count.marko
@@ -37,6 +37,16 @@ $ const optionsMap = {
       }
     `,
     variables: { input: params },
+  },
+  "magazine-active-issues": {
+    query: gql`
+      query MagazineActiveIssuesCount($input: MagazineActiveIssuesQueryInput!) {
+        result: magazineActiveIssues(input: $input) {
+          totalCount
+        }
+      }
+    `,
+    variables: { input: params },
   }
 };
 $ const options = optionsMap[input.name];

--- a/packages/global/routes/index.js
+++ b/packages/global/routes/index.js
@@ -1,6 +1,7 @@
 const htmlSitemap = require('@parameter1/base-cms-marko-web-html-sitemap/routes');
 const feed = require('./feed');
 const identityX = require('./identity-x');
+const magazine = require('../components/magazine/routes');
 const nativeX = require('./native-x');
 const omedaNewsletters = require('./omeda-newsletters');
 const printContent = require('./print-content');
@@ -15,6 +16,9 @@ module.exports = (app, siteConfig) => {
 
   // IdentityX (user routing and app context)
   identityX(app);
+
+  // Magazine Routes
+  magazine(app);
 
   // Omeda newsletter signup
   omedaNewsletters(app);

--- a/sites/aquamagazine.com/config/site.js
+++ b/sites/aquamagazine.com/config/site.js
@@ -18,6 +18,9 @@ module.exports = {
   search,
   subscribe,
   company: 'AB Media, Inc.',
+  publicationIds: [
+    '60f9819fd28860bc33754896',
+  ],
   p1events: {
     tenant: 'abmedia',
     enabled: true,

--- a/sites/athleticbusiness.com/config/site.js
+++ b/sites/athleticbusiness.com/config/site.js
@@ -16,6 +16,9 @@ module.exports = {
   newsletter,
   search,
   company: 'AB Media, Inc.',
+  publicationIds: [
+    '60f981d5d28860bc33766203',
+  ],
   subscribe,
   p1events: {
     tenant: 'abmedia',

--- a/sites/woodfloorbusiness.com/config/site.js
+++ b/sites/woodfloorbusiness.com/config/site.js
@@ -17,6 +17,9 @@ module.exports = {
   search,
   subscribe,
   company: 'AB Media, Inc.',
+  publicationIds: [
+    '60f981b6d28860bc3375bcf7',
+  ],
   p1events: {
     tenant: 'abmedia',
     enabled: true,


### PR DESCRIPTION
Ported from diverse as a starting point and added logic to restrict which publications show up on each site based on the list of publicationIds array in the site config.
<img width="408" alt="Screen Shot 2021-09-28 at 12 54 34 PM" src="https://user-images.githubusercontent.com/3845869/135149932-8096d488-b871-4849-9aeb-1b929d9934c1.png">
<img width="393" alt="Screen Shot 2021-09-28 at 12 55 26 PM" src="https://user-images.githubusercontent.com/3845869/135149951-73a80858-148c-4a26-91db-aacbe83e5324.png">


