### PR TITLE
Adjust ad css for tablets

### DIFF
--- a/packages/global/scss/components/_ads.scss
+++ b/packages/global/scss/components/_ads.scss
@@ -146,8 +146,8 @@
   }
 
   &--template-leaderboard {
-    min-height: 50px + $container-height;
-    @media (min-width: 750px) {
+    min-height: 100px + $container-height;
+    @media (min-width: 780px) {
       min-height: 250px + $container-height;
     }
   }
@@ -156,7 +156,7 @@
   &--template-inline-content-desktop,
   &--template-inline-content-mobile {
     min-height: 50px + $container-height;
-    @media (min-width: 750px) {
+    @media (min-width: 780px) {
       min-height: 90px + $container-height;
     }
   }


### PR DESCRIPTION
**Before:**
<img width="558" alt="Screen Shot 2021-10-01 at 12 35 19 PM" src="https://user-images.githubusercontent.com/2855198/135665456-dc26d2cc-f989-4e79-a998-2a1cba703f23.png">

**After:**
<img width="554" alt="Screen Shot 2021-10-01 at 12 49 18 PM" src="https://user-images.githubusercontent.com/2855198/135665479-7620f8b3-28b4-46d8-a7e6-846cc37218b7.png">
