### PR TITLE
Replace ‘wood flooring’ block with ‘news’ block for WFB

### DIFF
--- a/sites/woodfloorbusiness.com/server/templates/index.marko
+++ b/sites/woodfloorbusiness.com/server/templates/index.marko
@@ -39,8 +39,8 @@ $ const { site } = out.global;
     <global-gear-block alias="new-products" />
   </@section>
 
-  <@section>
-    <global-reader-rigs-block alias="wood-flooring" default-description="" />
+  <@section|{ aliases }| modifiers=["break-container"]>
+    <global-opinion-block alias="news" />
   </@section>
 
   <@section|{ aliases }|>


### PR DESCRIPTION
<img width="1269" alt="Screen Shot 2021-10-04 at 12 27 26 PM" src="https://user-images.githubusercontent.com/64623209/135896847-23f68c9c-d503-48b3-a30f-76f422fec063.png">
