### PR TITLE
Add content with same taxonomy id as content page to Related Stories block.

### DIFF
--- a/packages/global/components/blocks/related-stories.marko
+++ b/packages/global/components/blocks/related-stories.marko
@@ -1,6 +1,6 @@
 import queryFragment from "../../graphql/fragments/related-stories-block";
 
-$ const { contentId, sectionId } = input;
+$ const { contentId, sectionId, taxonomyIds } = input;
 $ const limit = 4;
 $ const queryParams = {
   contentId,
@@ -19,9 +19,29 @@ $ const blockName = "related-stories";
     <marko-web-query|{ nodes: related }|
       name="website-scheduled-content"
       params={ sectionId, limit: limit - nodes.length, excludeContentIds, requiresImage: true, queryFragment }
+      collapsible=false
     >
-      $ nodes.push(...related);
-      <if(nodes.length)>
+        $ nodes.push(...related);
+        $ excludeContentIds.push(...related.map(node => node.id));
+        <if(nodes.length < limit && taxonomyIds.length)>
+          <!-- query for more content -->
+          <marko-web-query|{ nodes: taxonomyItems }|
+            name="all-published-content"
+            params={
+                excludeContentIds,
+                includeTaxonomyIds: taxonomyIds,
+                limit: limit - nodes.length,
+                requiresImage: true,
+                queryFragment,
+              }
+            >
+            $ nodes.push(...taxonomyItems);
+            <global-content-card-deck-4-col-flow nodes=nodes modifiers=[blockName]>
+              <@node modifiers=[blockName] />
+            </global-content-card-deck-4-col-flow>
+          </marko-web-query>
+      </if>
+      <else>
         <marko-web-block name=blockName>
           <marko-web-element block-name=blockName name="header">
             ${title}
@@ -30,7 +50,7 @@ $ const blockName = "related-stories";
             <@node modifiers=[blockName] />
           </global-content-card-deck-4-col-flow>
         </marko-web-block>
-      </if>
+      </else>
     </marko-web-query>
   </if>
   <else>

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -179,6 +179,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
     <global-related-stories-block
       content-id=content.id
       section-id=content.primarySection.id
+      taxonomy-ids=content.taxonomyIds
     />
   </@section>
 

--- a/packages/global/graphql/fragments/content-page.js
+++ b/packages/global/graphql/fragments/content-page.js
@@ -8,6 +8,7 @@ fragment ContentPageFragment on Content {
   labels
   body
   published
+  taxonomyIds
   siteContext {
     path
     canonicalUrl


### PR DESCRIPTION
<img width="1919" alt="Screen Shot 2021-10-22 at 10 19 44 AM" src="https://user-images.githubusercontent.com/46794001/138480851-e0b58693-6566-4d76-8194-8706fbd044b3.png">

This will backfill the related stories block with taxonomy id matched content if the block isn't already occupied to 4 pieces of content coming from either specified related content or content within the same primary section. This is similar to the current logic on Industrial Media added here: https://github.com/parameter1/industrial-media-websites/pull/157

EDIT: Setting this as draft as due to other data corrections the problem this was solving doesn't appear to be a problem, at least not nearly as often as it was prior to those corrections.

EDIT 2: Now closing due to previous comment/resolution of issue this was intended to solve.