### PR TITLE
Sort on published desc, up limit.

### DIFF
--- a/packages/global/components/blocks/directory-featured-projects.marko
+++ b/packages/global/components/blocks/directory-featured-projects.marko
@@ -22,8 +22,8 @@ $ const convertEntry = (entry) => {
     query DirectoryFeaturedProjectsBlock($shortIds: [String!]!) {
       entries(input: {
         includeIdentifiers: { shortIds: $shortIds }
-        pagination: { limit: 50 }
-        sort: { field: TITLE, order: ASC }
+        pagination: { limit: 70 }
+        sort: { field: PUBLISHED_AT, order: DESC }
       }) {
         edges {
           node {

--- a/packages/global/components/blocks/directory-featured-projects.marko
+++ b/packages/global/components/blocks/directory-featured-projects.marko
@@ -22,7 +22,7 @@ $ const convertEntry = (entry) => {
     query DirectoryFeaturedProjectsBlock($shortIds: [String!]!) {
       entries(input: {
         includeIdentifiers: { shortIds: $shortIds }
-        pagination: { limit: 70 }
+        pagination: { limit: 100 }
         sort: { field: PUBLISHED_AT, order: DESC }
       }) {
         edges {


### PR DESCRIPTION
This limit now accounts for https://www.athleticbusiness.com/directory/consultants/components/aquatics/company/15137431/counsilman-hunsaker which has 70 entries. The previous limit was 50.
<img width="1919" alt="Screen Shot 2021-12-06 at 3 21 20 PM" src="https://user-images.githubusercontent.com/46794001/144924811-97182462-360d-4f99-a4d2-4b372ae55c31.png">
<img width="1920" alt="Screen Shot 2021-12-06 at 3 21 28 PM" src="https://user-images.githubusercontent.com/46794001/144924819-82eac27b-b0d0-48e5-9feb-844f5f46d2c4.png">


