### PR TITLE
Adjust category and main landing page displayed "results", Buyer's Guide.

### DIFF
--- a/packages/global/templates/directory/index.marko
+++ b/packages/global/templates/directory/index.marko
@@ -81,13 +81,13 @@ $ const currentPage = search.getCurrentPage();
               <div>${new Intl.NumberFormat().format(totalCount)} Results</div>
               <marko-web-search-selected-filters />
             </@section>
-            <if(currentPage === 1 & !search.input.searchQuery)>
+            <if(currentPage === 1 && !search.input.searchQuery)>
               <@section  modifiers=["featured-listings"]>
                 $ const featuredParams = {
                   limit: 25,
                   sectionAlias: alias,
                   optionName: ["Pinned", "Standard"],
-                  sectionBubbling: false,
+                  sectionBubbling: true,
                   sort: { field: 'name', order: 'asc'},
                   queryFragment,
 
@@ -132,7 +132,7 @@ $ const currentPage = search.getCurrentPage();
                 </marko-web-query>
               </@section>
             </if>
-            <if(nodes.length)>
+            <if(nodes.length && search.input.searchQuery)>
               <@section>
                 <marko-web-node-list
                   inner-justified=true


### PR DESCRIPTION
This will now pull in Buyer's Guide Microsites and Advertisers to the directory landing as well as category landing pages unless a specific search is made.

<img width="1920" alt="Screen Shot 2021-12-07 at 8 04 35 AM" src="https://user-images.githubusercontent.com/46794001/145043792-17f893d7-7671-4d71-843e-892cf4337f67.png">
