### PR TITLE
Force primary image to display left on White Papers and Documents.

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -70,11 +70,16 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
         </else-if>
         <else-if(displayPrimaryImage)>
           $ let forceDisplay;
-          $ if (["contact", "whitepaper", "document"].includes(type)) forceDisplay = "left";
+          $ const modifiers = [];
+          $ if (["contact", "whitepaper", "document"].includes(type)) {
+            forceDisplay = "left";
+            modifiers.push('forced-left');
+          }
           $ if (type === "video") forceDisplay = "none";
           <global-primary-image-block
             obj=content.primaryImage
-            force-display=forceDisplay;
+            force-display=forceDisplay
+            modifiers=modifiers
           />
         </else-if>
 

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -70,7 +70,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
         </else-if>
         <else-if(displayPrimaryImage)>
           $ let forceDisplay;
-          $ if (type === "contact") forceDisplay = "left";
+          $ if (["contact", "whitepaper", "document"].includes(type)) forceDisplay = "left";
           $ if (type === "video") forceDisplay = "none";
           <global-primary-image-block
             obj=content.primaryImage

--- a/packages/global/scss/components/blocks/_primary-image.scss
+++ b/packages/global/scss/components/blocks/_primary-image.scss
@@ -70,6 +70,10 @@ $marko-web-primary-image-margin: 1.5rem !default;
     }
   }
 
+  &--forced-left {
+    margin-bottom: 1.5rem;
+  }
+
   @each $ar in $marko-web-node-image-aspect-ratios {
     $x: nth($ar, 1);
     $y: nth($ar, 2);


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2021-12-15 at 1 24 41 PM" src="https://user-images.githubusercontent.com/46794001/146276218-d434b5f6-3fed-4a79-959b-016d1cb83ecd.png">



As an additional note: Contacts have been moved as it stands currently to their own template across the Monorail theme, this template uses a different block entirely to render the primary image and would not be affected by the --forced-left primary image modifier.