### PR TITLE
Use site config value to enable/disable billboard ad.

### DIFF
--- a/packages/global/components/blocks/leaderboard-ad.marko
+++ b/packages/global/components/blocks/leaderboard-ad.marko
@@ -1,21 +1,33 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { get } from "@parameter1/base-cms-object-path";
 
-$ const { GAM } = out.global;
+$ const { GAM, site } = out.global;
 $ const { hasCookie, referrer, cookieName } = get(out.global, "billboardState");
 $ const name = (!hasCookie && referrer === "internal") ? "billboard" : "leaderboard";
 $ const adUnit = GAM.getAdUnit({ name, aliases: input.aliases });
 $ const expires = 1/24; // Days
+$ const allowBillboard = defaultValue(site.get("allowBillboard"), true)
 
-<if(name === "billboard")>
+$ console.log(allowBillboard)
+
+<if(name === "billboard" && allowBillboard)>
   <marko-web-browser-component
     name="GlobalBillboardCookie"
     props={ adUnitPath: adUnit.path, cookieName, expires }
   />
+  <theme-gam-define-display-ad
+    name=name
+    position=input.position
+    aliases=input.aliases
+    modifiers=input.modifiers
+  />
 </if>
 
-<theme-gam-define-display-ad
-  name=name
-  position=input.position
-  aliases=input.aliases
-  modifiers=input.modifiers
-/>
+<else-if (name !=="billboard")>
+  <theme-gam-define-display-ad
+    name=name
+    position=input.position
+    aliases=input.aliases
+    modifiers=input.modifiers
+  />
+</else-if>

--- a/packages/global/components/blocks/leaderboard-ad.marko
+++ b/packages/global/components/blocks/leaderboard-ad.marko
@@ -8,8 +8,6 @@ $ const adUnit = GAM.getAdUnit({ name, aliases: input.aliases });
 $ const expires = 1/24; // Days
 $ const allowBillboard = defaultValue(site.get("allowBillboard"), true)
 
-$ console.log(allowBillboard)
-
 <if(name === "billboard" && allowBillboard)>
   <marko-web-browser-component
     name="GlobalBillboardCookie"

--- a/sites/athleticbusiness.com/config/site.js
+++ b/sites/athleticbusiness.com/config/site.js
@@ -68,4 +68,5 @@ module.exports = {
     logo: 'https://img.athleticbusiness.com/files/base/abmedia/all/image/static/ab/ab-logo.png?h=60&auto=format,compress&q=70&bg=FFFFFF&pad=5',
     bgColor: '#FFFFFF',
   },
+  allowBillboard: false,
 };


### PR DESCRIPTION
(Screenshot to show that leaderboard is unaffected)
<img width="1792" alt="Screen Shot 2022-01-03 at 9 55 37 AM" src="https://user-images.githubusercontent.com/46794001/147951872-3694b273-18ff-41d1-a708-2fcd4b079e8c.png">


(Screenshot to show that billboard is removed)
<img width="1792" alt="Screen Shot 2022-01-03 at 9 55 43 AM" src="https://user-images.githubusercontent.com/46794001/147951888-74faba28-8d50-4074-8a68-fe82ab6daa92.png">

