### PR TITLE
Update prop from path to url to fix social sharing functionality

### DIFF
--- a/packages/global/templates/content/native-x-story.marko
+++ b/packages/global/templates/content/native-x-story.marko
@@ -33,7 +33,7 @@ $ const { primarySection } = content;
             <theme-primary-image-block obj=content.primaryImage />
             <marko-web-content-body block-name=blockName obj=content />
             <marko-web-social-sharing
-              path=content.siteContext.path
+              url=content.siteContext.path
               providers=["facebook", "linkedin", "twitter", "pinterest"]
             />
           </default-theme-page-contents>


### PR DESCRIPTION
Update to use the url prop vs the path prop which was adding the domain twice.  

```js
$ let printUrl;
$ if (input.printUrl) {
  printUrl = input.printUrl;
} else if (input.printPath) {
  printUrl = `${out.global.requestOrigin}/${cleanPath(input.printPath)}`;
}
```
<img width="1188" alt="Screen Shot 2022-06-06 at 9 22 44 AM" src="https://user-images.githubusercontent.com/3845869/172180227-e2898b89-f472-40fe-8342-6129ab5466b7.png">


