### PR TITLE
Add Lines Carried & Sales Regions fields to company pages

### DIFF
--- a/packages/global/components/layouts/content/company-details.marko
+++ b/packages/global/components/layouts/content/company-details.marko
@@ -12,7 +12,7 @@ $ const showPhones = phoneFields.some(k => content[k]);
 $ const socialLinks = getAsArray(content, "socialLinks");
 $ const showSocial = socialLinks.length;
 
-$ const fields = ["title", "website"];
+$ const fields = ["title", "website", "linesCarried", "salesRegion"];
 $ if (showEmail) fields.push("publicEmail");
 $ const showFields = fields.some(k => content[k]);
 
@@ -46,6 +46,22 @@ $ const showFields = fields.some(k => content[k]);
         <div class=`${blockName}__field`>
           <span class=`${blockName}__label`>Website:</span>
           <marko-web-content-website block-name=blockName obj=content link=true />
+        </div>
+      </if>
+      <if(content.salesRegion)>
+        <div class=`${blockName}__field`>
+          <span class=`${blockName}__label`>Sales Regions:</span>
+          <marko-web-element block-name=blockName name="sales-region">
+            ${content.salesRegion}
+          </marko-web-element>
+        </div>
+      </if>
+      <if(content.linesCarried)>
+        <div class=`${blockName}__field`>
+          <span class=`${blockName}__label`>Lines Carried:</span>
+          <marko-web-element block-name=blockName name="lines-carried">
+            ${content.linesCarried}
+          </marko-web-element>
         </div>
       </if>
     </default-theme-content-contact-details-section>

--- a/packages/global/graphql/fragments/content-page.js
+++ b/packages/global/graphql/fragments/content-page.js
@@ -98,6 +98,10 @@ fragment ContentPageFragment on Content {
   }
   ... on ContentCompany {
     email
+    salesRegion
+    linesCarried: customAttribute(input: {
+      path: "linesCarried"
+    })
     websiteSchedules {
       section {
         id


### PR DESCRIPTION
This wont show up until we run scripts to map these fields. https://github.com/parameter1/base-scripts/pull/110 & https://github.com/parameter1/base-imports/pull/72 
<img width="1111" alt="Screen Shot 2022-07-27 at 10 21 16 AM" src="https://user-images.githubusercontent.com/3845869/181286122-5aacc032-6392-41ad-a4a9-bc16949a2af2.png">
