### PR TITLE
Display salesRegion field as Areas Served on company pages

### DIFF
--- a/packages/global/components/layouts/content/company-details.marko
+++ b/packages/global/components/layouts/content/company-details.marko
@@ -50,7 +50,7 @@ $ const showFields = fields.some(k => content[k]);
       </if>
       <if(content.salesRegion)>
         <div class=`${blockName}__field`>
-          <span class=`${blockName}__label`>Sales Regions:</span>
+          <span class=`${blockName}__label`>Areas Served:</span>
           <marko-web-element block-name=blockName name="sales-region">
             ${content.salesRegion}
           </marko-web-element>


### PR DESCRIPTION
![Areas-served](https://user-images.githubusercontent.com/46794001/181533142-f05b83dd-c388-4123-ad3d-9ab4dd905b01.png)
