### PR TITLE
Add logic to fire billboard in correct spot on content routes

### DIFF
--- a/packages/global/components/blocks/leaderboard-ad.marko
+++ b/packages/global/components/blocks/leaderboard-ad.marko
@@ -1,7 +1,8 @@
 import { get } from "@parameter1/base-cms-object-path";
-
+$ const leaderboardZoneAlias = input.leaderboardZoneAlias || 'leaderboard';
+$ const billboardZoneAlias = input.billboardZoneAlias || 'billboard';
 $ const { hasCookie, cookieValue, cookieName } = get(out.global, "billboardState");
-$ const name = (hasCookie && cookieValue === "0") ? "billboard" : "leaderboard";
+$ const name = (hasCookie && cookieValue === "0") ? billboardZoneAlias : leaderboardZoneAlias;
 $ const expires = 1/24; // Days
 
 <if(!hasCookie)>
@@ -16,7 +17,6 @@ $ const expires = 1/24; // Days
     props={ cookieName, cookieValue: "1", expires }
   />
 </else-if>
-
 
 <marko-web-broadstreet-zone
   zone-alias=name

--- a/packages/global/components/layouts/content/components/content-body-with-injection.marko
+++ b/packages/global/components/layouts/content/components/content-body-with-injection.marko
@@ -2,6 +2,7 @@ import { getAsArray } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import MarkoWebContentBody from "@parameter1/base-cms-marko-web/components/element/content/body";
 import BAMZone from "@ab-media/base-cms-marko-web-broadstreet/components/zone";
+import LeaderboardAd from "../../../blocks/leaderboard-ad";
 import GlobalLeadersContextual from "../../../leaders/contextual";
 
 $ const { global: $global } = out;
@@ -38,8 +39,9 @@ $ const mobileCounts = [900, 1650, 2950, 4250, 5550, 6850, 8150, 9450, 10750, 12
 
     <@inject
       at=250
-      html=BAMZone.renderToString({
-        zoneAlias: "mobileLeaderboard",
+      html=LeaderboardAd.renderToString({
+        billboardZoneAlias: "mobileBillboard",
+        leaderboardZoneAlias: "mobileLeaderboard",
         modifiers: ["margin-auto-x",  "inline-content", "inline-content-mobile", "inline-leaderboard-mobile"],
         $global
       })

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -26,8 +26,8 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
 >
   <@section|{ aliases }| modifiers=["break-container", "first-sm"]>
     <global-leaderboard-ad-block
-      position="content_page"
-      aliases=aliases
+      billboardZoneAlias="desktopBillboard"
+      leadboardZoneAlias="desktopLeaderboard"
       modifiers=["inter-block", "combined-leaderboard", "content-leaderboard"]
     />
   </@section>

--- a/sites/aquamagazine.com/config/bam.js
+++ b/sites/aquamagazine.com/config/bam.js
@@ -18,6 +18,22 @@ module.exports = ({
         ['(max-width: 980px)', 147847],
       ],
     },
+    // for use in content pages when positions move
+    desktopBillboard: {
+      zoneIdSizeMapping: [
+        ['(min-width: 980px)', 99655],
+      ],
+    },
+    mobileBillboard: {
+      zoneIdSizeMapping: [
+        ['(max-width: 980px)', 99655],
+      ],
+    },
+    desktopLeaderboard: {
+      zoneIdSizeMapping: [
+        ['(min-width: 980px)', 99656],
+      ],
+    },
     desktopRotation: {
       zoneIdSizeMapping: [
         ['(min-width: 980px)', 99657],

--- a/sites/athleticbusiness.com/config/bam.js
+++ b/sites/athleticbusiness.com/config/bam.js
@@ -18,6 +18,22 @@ module.exports = ({
         ['(max-width: 980px)', 147422],
       ],
     },
+    // for use in content pages when positions move
+    desktopBillboard: {
+      zoneIdSizeMapping: [
+        ['(min-width: 980px)', 99650],
+      ],
+    },
+    mobileBillboard: {
+      zoneIdSizeMapping: [
+        ['(max-width: 980px)', 99650],
+      ],
+    },
+    desktopLeaderboard: {
+      zoneIdSizeMapping: [
+        ['(min-width: 980px)', 99648],
+      ],
+    },
     desktopRotation: {
       zoneIdSizeMapping: [
         ['(min-width: 980px)', 99649],

--- a/sites/woodfloorbusiness.com/config/bam.js
+++ b/sites/woodfloorbusiness.com/config/bam.js
@@ -18,6 +18,22 @@ module.exports = ({
         ['(max-width: 980px)', 147850],
       ],
     },
+    // for use in content pages when positions move
+    desktopBillboard: {
+      zoneIdSizeMapping: [
+        ['(min-width: 980px)', 99652],
+      ],
+    },
+    mobileBillboard: {
+      zoneIdSizeMapping: [
+        ['(max-width: 980px)', 99652],
+      ],
+    },
+    desktopLeaderboard: {
+      zoneIdSizeMapping: [
+        ['(min-width: 980px)', 99653],
+      ],
+    },
     desktopRotation: {
       zoneIdSizeMapping: [
         ['(min-width: 980px)', 99654],


### PR DESCRIPTION
when on mobil only fire it in the content body and not at the top of the page and when on desktop fire it at the top as expected.