### PR TITLE
Add template and route overrides for /magazine routes

### DIFF
--- a/packages/global/routes/index.js
+++ b/packages/global/routes/index.js
@@ -1,5 +1,4 @@
 const htmlSitemap = require('@parameter1/base-cms-marko-web-html-sitemap/routes');
-const magazine = require('@parameter1/base-cms-marko-web-theme-monorail-magazine/routes');
 const omedaNewsletters = require('@parameter1/base-cms-marko-web-omeda/routes/omeda-newsletters');
 const renderBlock = require('@parameter1/base-cms-marko-web-theme-monorail/routes/render-block');
 const searchTemplate = require('../templates/search');
@@ -9,6 +8,7 @@ const nativeX = require('./native-x');
 const printContent = require('./print-content');
 const publicFiles = require('./public-files');
 const redirects = require('./redirects');
+const magazine = require('./magazine');
 
 module.exports = (app, siteConfig) => {
   // Digital Edition

--- a/packages/global/routes/magazine.js
+++ b/packages/global/routes/magazine.js
@@ -1,0 +1,24 @@
+const publicationFragment = require('@parameter1/base-cms-marko-web-theme-monorail-magazine/graphql/fragments/magazine-publication-page');
+const issueFragment = require('@parameter1/base-cms-marko-web-theme-monorail-magazine/graphql/fragments/magazine-issue-page');
+
+const { withMagazineIssue, withMagazinePublication } = require('@parameter1/base-cms-marko-web/middleware');
+const index = require('../templates/magazine/index');
+const publication = require('../templates/magazine/publication');
+const issue = require('../templates/magazine/issue');
+
+
+module.exports = (app) => {
+  app.get('/magazine', (req, res) => {
+    res.marko(index);
+  });
+
+  app.get('/magazine/:id([a-fA-F0-9]{24})', withMagazinePublication({
+    template: publication,
+    queryFragment: publicationFragment,
+  }));
+
+  app.get('/magazine/:id(\\d+)', withMagazineIssue({
+    template: issue,
+    queryFragment: issueFragment,
+  }));
+};

--- a/packages/global/templates/magazine/index.marko
+++ b/packages/global/templates/magazine/index.marko
@@ -1,0 +1,36 @@
+$ const { site } = out.global;
+
+$ const type = "magazines";
+$ const title = "Magazines";
+$ const description = site.get("magazines.description");
+
+<marko-web-default-page-layout type=type title=title description=description>
+  <@head>
+    <marko-web-gtm-default-context|{ context }| type=type>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-default-context>
+  </@head>
+  <@page>
+    <marko-web-page-wrapper class="mb-block">
+      <@section|{ aliases }|>
+        <global-leaderboard-ad-block
+          position="section_page"
+          aliases=aliases
+          modifiers=["inter-block", "combined-leaderboard"]
+        />
+      </@section>
+
+      <@section>
+        <div class="row">
+          <div class="col">
+            <h1 class="page-wrapper__title">${title}</h1>
+            <if(description)>
+              <p class="page-wrapper__deck">${description}</p>
+            </if>
+          </div>
+        </div>
+        <theme-magazine-publications-block with-header=false />
+      </@section>
+    </marko-web-page-wrapper>
+  </@page>
+</marko-web-default-page-layout>

--- a/packages/global/templates/magazine/issue.marko
+++ b/packages/global/templates/magazine/issue.marko
@@ -1,0 +1,102 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import issueFragment from "@parameter1/base-cms-marko-web-theme-monorail-magazine/graphql/fragments/magazine-issue-archive";
+
+$ const { site } = out.global;
+$ const { id, pageNode } = data;
+
+<marko-web-magazine-issue-page-layout id=id>
+  <@head>
+    <marko-web-gtm-magazine-issue-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-magazine-issue-context>
+  </@head>
+  <@page>
+    <marko-web-page-wrapper class="mb-block">
+      <@section|{ aliases }|>
+        <global-leaderboard-ad-block
+          position="section_page"
+          aliases=aliases
+          modifiers=["inter-block", "combined-leaderboard"]
+        />
+      </@section>
+
+      <@section>
+        <div class="row">
+          <div class="col">
+            <marko-web-resolve-page|{ data: issue }| node=pageNode>
+              <theme-breadcrumbs modifiers=["website-section"]>
+                <@item><marko-web-link href="/magazine">Magazine</marko-web-link></@item>
+                <@item><marko-web-magazine-publication-name tag=null obj=issue.publication link=true /></@item>
+              </theme-breadcrumbs>
+              <div class="magazine-publication-card-block">
+                <div class="magazine-publication-card-block__body">
+                  <div class="row">
+                    <div class="col-lg-8 pl-0">
+                      <marko-web-node image-position="left" modifiers=["flush"] flush=false>
+                        <@image
+                          src=issue.coverImage.src
+                          alt=(issue.coverImage.alt || issue.name)
+                          fluid=false
+                          ar="3:4"
+                          width=300
+                          options={ fit: "max" }
+                        />
+                        <@body>
+                          <@title tag="h1">
+                            <marko-web-magazine-issue-name tag=null obj=issue />
+                          </@title>
+                          <@text modifiers=["teaser"]>
+                            <marko-web-magazine-issue-description tag=null obj=issue />
+                          </@text>
+                          <@footer>
+                            <@left>
+                              <theme-magazine-publication-buttons issue=issue />
+                            </@left>
+                          </@footer>
+                        </@body>
+                      </marko-web-node>
+                    </div>
+                    <marko-web-query|{ nodes: issues }| name="magazine-active-issues"
+                      params={
+                        publicationId: issue.publication.id,
+                        excludeIssueIds: [issue.id],
+                        queryFragment: issueFragment,
+                        limit: 9,
+                        requiresCoverImage: true
+                      }
+                    >
+                      <div class="col-lg-4">
+                        <div class="row">
+                          <for|issue| of=issues>
+                            <div class="col-4 issue-archive-cover">
+                              <marko-web-node
+                                image-position="top"
+                                card=true
+                                flush=true
+                                full-height=true
+                              >
+                                <@image
+                                  src=issue.coverImage.src
+                                  alt=(issue.coverImage.alt || issue.name)
+                                  fluid=true
+                                  ar="3:4"
+                                  width=190
+                                  link={ href: issue.canonicalPath, title: issue.name }
+                                  options={ fit: "max" }
+                                />
+                              </marko-web-node>
+                            </div>
+                          </for>
+                        </div>
+                      </div>
+                    </marko-web-query>
+                  </div>
+                </div>
+              </div>
+            </marko-web-resolve-page>
+          </div>
+        </div>
+      </@section>
+    </marko-web-page-wrapper>
+  </@page>
+</marko-web-magazine-issue-page-layout>

--- a/packages/global/templates/magazine/publication.marko
+++ b/packages/global/templates/magazine/publication.marko
@@ -1,0 +1,69 @@
+import issueFragment from "@parameter1/base-cms-marko-web-theme-monorail-magazine/graphql/fragments/magazine-issue-archive";
+
+$ const { pagination: p, req } = out.global;
+$ const { id, pageNode } = data;
+$ const perPage = 16;
+
+<marko-web-magazine-publication-page-layout id=id>
+  <@head>
+    <marko-web-gtm-magazine-publication-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-magazine-publication-context>
+  </@head>
+  <@page>
+    <marko-web-page-wrapper>
+      <@section|{ aliases }|>
+        <global-leaderboard-ad-block
+          position="section_page"
+          aliases=aliases
+          modifiers=["inter-block", "combined-leaderboard"]
+        />
+      </@section>
+
+      <@section>
+        <div class="row">
+          <div class="col">
+            <theme-breadcrumbs modifiers=["website-section"]>
+              <@item><marko-web-link href="/magazine">Magazine</marko-web-link></@item>
+            </theme-breadcrumbs>
+            <marko-web-resolve-page|{ data: publication }| node=pageNode>
+              <h1 class="page-wrapper__title">
+                ${publication.name} Issue Archive
+                <if(p.page > 1)>: Page ${p.page}</if>
+              </h1>
+              <if(publication.description)>
+                <p class="page-wrapper__deck">${publication.description}</p>
+              </if>
+            </marko-web-resolve-page>
+          </div>
+        </div>
+      </@section>
+      <@section>
+        <marko-web-resolve-page|{ data: publication }| node=pageNode>
+          $ const params = {
+            publicationId: id,
+            limit: perPage,
+            skip:p.skip({ perPage }),
+            queryFragment: issueFragment,
+            requiresCoverImage: true,
+          };
+          <marko-web-query|{ nodes }|
+            name="magazine-active-issues"
+            params=params
+          >
+            <theme-magazine-issue-archive-flow nodes=nodes flush=true />
+          </marko-web-query>
+          <div class="mb-block">
+            <theme-query-total-count|{ totalCount }| name="magazine-active-issues" params={publicationId: id}>
+              <theme-pagination-controls
+                per-page=perPage
+                total-count=totalCount
+                path=req.path
+              />
+            </theme-query-total-count>
+          </div>
+        </marko-web-resolve-page>
+      </@section>
+    </marko-web-page-wrapper>
+  </@page>
+</marko-web-magazine-publication-page-layout>


### PR DESCRIPTION
Add these templates and routes to the ab website repo to account for the new Broadstreet ad system.