### PR TITLE
Add support for both leader & standard logos

### DIFF
--- a/packages/global/components/layouts/content/company-details/company-logo.marko
+++ b/packages/global/components/layouts/content/company-details/company-logo.marko
@@ -2,7 +2,7 @@ import { get, getAsObject } from "@parameter1/base-cms-object-path";
 import { buildImgixUrl } from "@parameter1/base-cms-image";
 
 $ const { content } = input;
-$ const image = getAsObject(content, "primaryImage");
+$ const image = getAsObject(content, "leadersLogo");
 $ const blockName = "company-logo";
 
 $ const hasImage = Boolean(image.src);

--- a/packages/global/graphql/fragment-factories/content-company.js
+++ b/packages/global/graphql/fragment-factories/content-company.js
@@ -51,10 +51,23 @@ fragment LeadersWebsiteContentCompanyFragment on Content {
     warrantyInformation
 
     # circle image
-    primaryImage {
+    leadersLogo: primaryImage {
       id
       src(input: { options: { auto: "format,compress", q: 70, fillColor: "fff", fit: "fill", h: 125, w: 125, pad: 5, mask: "ellipse" } })
       alt
+    }
+
+    primaryImage {
+      id
+      src(input: { useCropRectangle: true, options: { auto: "format,compress", q: 70 } })
+      alt
+      caption
+      credit
+      isLogo
+      cropDimensions {
+        aspectRatio
+      }
+      primaryImageDisplay
     }
 
     isLeader: hasWebsiteSchedule(input: { sectionAlias: "${leadersAlias}" })


### PR DESCRIPTION
Add new custom leadersLogo on content company & use that in company logo component

<img width="1130" alt="Screen Shot 2022-10-04 at 4 01 02 PM" src="https://user-images.githubusercontent.com/3845869/193928630-0df62616-7fd3-4693-8fbd-204d0306c779.png">
<img width="1179" alt="Screen Shot 2022-10-04 at 4 03 14 PM" src="https://user-images.githubusercontent.com/3845869/193928633-7cadda34-ea19-4dd6-877d-a1f493122e3f.png">
