### PR TITLE
Assert children companies exist before retrieval on company pages

### DIFF
--- a/packages/global/components/layouts/content/company.marko
+++ b/packages/global/components/layouts/content/company.marko
@@ -95,8 +95,8 @@ $ const lang = site.config.lang || "en";
             </default-theme-page-contents>
           </div>
 
-        $ const childCompanies = getAsArray(content.children.edges).map((edge) => edge.node);
-        <if(childCompanies)>
+        $ const childCompanies = content.children ? getAsArray(content.children.edges).map((edge) => edge.node) : [];
+        <if(childCompanies.length)>
           <p><b>Branch Locations</b></p>
           <div class="row">
             <for|childCompany| of=childCompanies>


### PR DESCRIPTION
PROD:
![Prod](https://user-images.githubusercontent.com/46794001/195660543-6659bfd1-6277-4e75-a9c1-200cf87ce7bf.png)

DEV:
![DEV2](https://user-images.githubusercontent.com/46794001/195660549-d4d06d47-9727-4c05-a0f7-5e76941a6f42.png)

Branch Locations still appear where applicable:
![Branch-Locations-Loading](https://user-images.githubusercontent.com/46794001/195660550-8ec3dadd-75f3-4818-b0ef-8639a76a332c.png)
