### PR TITLE
Add env onlyVisible Broadstreet ad config support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ x-env-defaults: &env
   LEADERS_ENABLED: ${LEADERS_ENABLED-false}
   LEADERS_ALIAS: ${LEADERS_ALIAS-}
   LEADERS_LOGO: ${LEADERS_LOGO-}
+  BAM_ONLY_VISIBLE: ${BAM_ONLY_VISIBLE-false}
 
 x-env-virgon-dev: &env-virgon-dev
   GRAPHQL_URI: ${GRAPHQL_URI-http://host.docker.internal:10103}

--- a/packages/broadstreet/components/init.marko
+++ b/packages/broadstreet/components/init.marko
@@ -22,11 +22,14 @@
 ** "zoneOptions": {}       // options for an individual zone (overrides global options)
 **
 */
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
 $ const src = input.src || "https://cdn.broadstreetads.com/init-2.min.js";
 $ const { on, config } = input;
 $ const { networkId } = config;
+$ const onlyVisible = defaultValue(config.onlyVisible, false)
 
-$ const createContainerScript = `window.broadstreet = window.broadstreet || { run: [] }; window.broadstreet.run.push(function() { broadstreet.loadNetworkJS(${ networkId }); });`;
+$ const createContainerScript = `window.broadstreet = window.broadstreet || { run: [] }; window.broadstreet.run.push(function() { broadstreet.watch({networkId: ${ networkId }, onlyVisible: ${JSON.stringify(onlyVisible)} }); }); window.broadstreet.run.push(function() { broadstreet.loadNetworkJS(${ networkId }); });`;
 <if(on)>
   <marko-web-deferred-script-loader-register
     name="broadstreettag"

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -32,7 +32,7 @@ $ const omedaConfig = site.get('omeda');
       on="load"
       request-frame=true
       target-tag="body"
-      config={ networkId: BAM.networkId, useAltZone: BAM.useAltZone }
+      config=BAM
     />
 
     <!-- init gtm -->

--- a/sites/aquamagazine.com/config/bam.js
+++ b/sites/aquamagazine.com/config/bam.js
@@ -1,5 +1,10 @@
+const onlyVisible = (process.env.BAM_ONLY_VISIBLE && (process.env.BAM_ONLY_VISIBLE === true || process.env.BAM_ONLY_VISIBLE === 'true'))
+  ? { mobileScaling: 2.0, renderMarginPercent: 200 }
+  : false;
+
 module.exports = ({
   networkId: 7652,
+  onlyVisible,
   zones: {
     billboard: {
       zoneIdSizeMapping: [

--- a/sites/athleticbusiness.com/config/bam.js
+++ b/sites/athleticbusiness.com/config/bam.js
@@ -1,5 +1,10 @@
+const onlyVisible = (process.env.BAM_ONLY_VISIBLE && (process.env.BAM_ONLY_VISIBLE === true || process.env.BAM_ONLY_VISIBLE === 'true'))
+  ? { mobileScaling: 2.0, renderMarginPercent: 200 }
+  : false;
+
 module.exports = ({
   networkId: 7652,
+  onlyVisible,
   zones: {
     billboard: {
       zoneIdSizeMapping: [

--- a/sites/woodfloorbusiness.com/config/bam.js
+++ b/sites/woodfloorbusiness.com/config/bam.js
@@ -1,5 +1,10 @@
+const onlyVisible = (process.env.BAM_ONLY_VISIBLE && (process.env.BAM_ONLY_VISIBLE === true || process.env.BAM_ONLY_VISIBLE === 'true'))
+  ? { mobileScaling: 2.0, renderMarginPercent: 200 }
+  : false;
+
 module.exports = ({
   networkId: 7652,
+  onlyVisible,
   zones: {
     billboard: {
       zoneIdSizeMapping: [


### PR DESCRIPTION
Add the ability to enable/config  only visible Broadstreet ads.

Adding this with env properties as there seems to be an issue with detecting when specific ads are in-view and the continuous checking to see if it is in view appears to eventually crash the browser.  This is to work with Broadstreet on trouble shooting within our staging env.  