### PR TITLE
Update broadstreet init function with default configs

### DIFF
--- a/packages/broadstreet/components/init.marko
+++ b/packages/broadstreet/components/init.marko
@@ -27,9 +27,15 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 $ const src = input.src || "https://cdn.broadstreetads.com/init-2.min.js";
 $ const { on, config } = input;
 $ const { networkId } = config;
-$ const onlyVisible = defaultValue(config.onlyVisible, false)
+$ const onlyVisible = defaultValue(config.onlyVisible, { mobileScaling: 2.0, renderMarginPercent: 200 });
+$ const uriKeywords = defaultValue(config.uriKeywords, true);
+$ const bamConfig = {
+  networkId,
+  onlyVisible,
+  uriKeywords,
+}
 
-$ const createContainerScript = `window.broadstreet = window.broadstreet || { run: [] }; window.broadstreet.run.push(function() { broadstreet.watch({networkId: ${ networkId }, onlyVisible: ${JSON.stringify(onlyVisible)} }); }); window.broadstreet.run.push(function() { broadstreet.loadNetworkJS(${ networkId }); });`;
+$ const createContainerScript = `window.broadstreet = window.broadstreet || { run: [] }; window.broadstreet.run.push(function() { broadstreet.watch(${JSON.stringify(bamConfig)}); });`;
 <if(on)>
   <marko-web-deferred-script-loader-register
     name="broadstreettag"


### PR DESCRIPTION
Update init call to also set the configurations for onlyVisible: { mobileScaling: 2.0, renderMarginPercent: 200 }  & uriKeywords: true

You can override from the config, but those are the default values for now.