### PR TITLE
Add our own intersectionObserver for lazyloading of Broadstreet ads

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ x-env-defaults: &env
   LEADERS_ALIAS: ${LEADERS_ALIAS-}
   LEADERS_LOGO: ${LEADERS_LOGO-}
   BAM_ONLY_VISIBLE: ${BAM_ONLY_VISIBLE-false}
+  BAM_LAZYLOAD_ENABLED: ${BAM_LAZYLOAD_ENABLED-true}
 
 x-env-virgon-dev: &env-virgon-dev
   GRAPHQL_URI: ${GRAPHQL_URI-http://host.docker.internal:10103}

--- a/packages/broadstreet/components/init.marko
+++ b/packages/broadstreet/components/init.marko
@@ -26,8 +26,8 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const src = input.src || "https://cdn.broadstreetads.com/init-2.min.js";
 $ const { on, config } = input;
-$ const { networkId } = config;
-$ const onlyVisible = defaultValue(config.onlyVisible, { mobileScaling: 2.0, renderMarginPercent: 200 });
+$ const { networkId, lazyload } = config;
+$ const onlyVisible = (lazyload && lazyload.enabled) ? false : defaultValue(config.onlyVisible, { mobileScaling: 2.0, renderMarginPercent: 200 });
 $ const uriKeywords = defaultValue(config.uriKeywords, true);
 $ const bamConfig = {
   networkId,

--- a/packages/broadstreet/components/zone.marko
+++ b/packages/broadstreet/components/zone.marko
@@ -22,13 +22,18 @@ $ const offset = lazyload.offset || "10%";
   <if(lazyload.enabled)>
     <script>
       (function() {
-        var lazyloadObserver = new IntersectionObserver((entries) => {
-          if (entries[0].isIntersecting) {
-            defineBroadstreetZone('${containerId}', ${JSON.stringify(sizeMapping)});
-            lazyloadObserver.unobserve(document.getElementById('${containerId}'));
-          }
-        }, { rootMargin: '0px 0px ${offset} 0px' });
-        lazyloadObserver.observe(document.getElementById('${containerId}'));
+        // Make sure IntersectionObservers are available.
+        if ('IntersectionObserver' in window) {
+          var lazyloadObserver = new IntersectionObserver((entries) => {
+            if (entries[0].isIntersecting) {
+              defineBroadstreetZone('${containerId}', ${JSON.stringify(sizeMapping)});
+              lazyloadObserver.unobserve(document.getElementById('${containerId}'));
+            }
+          }, { rootMargin: '0px 0px ${offset} 0px' });
+          lazyloadObserver.observe(document.getElementById('${containerId}'));
+        } else {
+          defineBroadstreetZone('${containerId}', ${JSON.stringify(sizeMapping)});
+        }
       })();
     </script>
   </if>

--- a/packages/broadstreet/components/zone.marko
+++ b/packages/broadstreet/components/zone.marko
@@ -5,19 +5,36 @@ $ const { BAM } = out.global;
 
 $ const { zoneAlias, zoneIdSizeMapping } = input;
 $ const blockName = input.blockName || "ad-container"
-$ const modifiers = getAsArray(input, 'modifiers');
+$ const modifiers = getAsArray(input, "modifiers");
 $ modifiers.push("broadstreet", "inter-block");
 
 $ const zone = getAsObject(BAM, `zones.${zoneAlias}`);
 $ const sizeMapping = zoneIdSizeMapping || zone.zoneIdSizeMapping;
-$ const containerId = randomElementId({ prefix: 'div-broadstreet-ad' });
+$ const containerId = randomElementId({ prefix: "div-broadstreet-ad" });
 
+$ const lazyload = getAsObject(BAM, "lazyload");
+$ const offset = lazyload.offset || "10%";
 <div
   class=[blockName, ...BEM.applyModifiers(blockName, modifiers), input.class]
   data-bam-zone-alias=zoneAlias
 >
   <div id=containerId class=`${blockName} ${blockName}__wrapper` />
-  <script>
-    defineBroadstreetZone('${containerId}', ${JSON.stringify(sizeMapping)});
-  </script>
+  <if(lazyload.enabled)>
+    <script>
+      (function() {
+        var lazyloadObserver = new IntersectionObserver((entries) => {
+          if (entries[0].isIntersecting) {
+            defineBroadstreetZone('${containerId}', ${JSON.stringify(sizeMapping)});
+            lazyloadObserver.unobserve(document.getElementById('${containerId}'));
+          }
+        }, { rootMargin: '0px 0px ${offset} 0px' });
+        lazyloadObserver.observe(document.getElementById('${containerId}'));
+      })();
+    </script>
+  </if>
+  <else>
+    <script>
+      defineBroadstreetZone('${containerId}', ${JSON.stringify(sizeMapping)});
+    </script>
+  </else>
 </div>

--- a/sites/aquamagazine.com/config/bam.js
+++ b/sites/aquamagazine.com/config/bam.js
@@ -1,10 +1,19 @@
-const onlyVisible = (process.env.BAM_ONLY_VISIBLE && (process.env.BAM_ONLY_VISIBLE === true || process.env.BAM_ONLY_VISIBLE === 'true'))
+// Our version of layzyload
+const BAM_LAZYLOAD_ENABLED = (process.env.BAM_LAZYLOAD_ENABLED && (process.env.BAM_LAZYLOAD_ENABLED === true || process.env.BAM_LAZYLOAD_ENABLED === 'true'));
+// Their version of lazyload...
+// In order to enable our version of lazyload must be disabled.
+const BAM_ONLY_VISIBLE = (process.env.BAM_ONLY_VISIBLE && (process.env.BAM_ONLY_VISIBLE === true || process.env.BAM_ONLY_VISIBLE === 'true'));
+const onlyVisible = (!BAM_LAZYLOAD_ENABLED && BAM_ONLY_VISIBLE)
   ? { mobileScaling: 2.0, renderMarginPercent: 200 }
   : false;
 
 module.exports = ({
   networkId: 7652,
   onlyVisible,
+  lazyload: {
+    enabled: BAM_LAZYLOAD_ENABLED,
+    offset: '10%',
+  },
   zones: {
     billboard: {
       zoneIdSizeMapping: [

--- a/sites/athleticbusiness.com/config/bam.js
+++ b/sites/athleticbusiness.com/config/bam.js
@@ -1,10 +1,19 @@
-const onlyVisible = (process.env.BAM_ONLY_VISIBLE && (process.env.BAM_ONLY_VISIBLE === true || process.env.BAM_ONLY_VISIBLE === 'true'))
+// Our version of layzyload
+const BAM_LAZYLOAD_ENABLED = (process.env.BAM_LAZYLOAD_ENABLED && (process.env.BAM_LAZYLOAD_ENABLED === true || process.env.BAM_LAZYLOAD_ENABLED === 'true'));
+// Their version of lazyload...
+// In order to enable our version of lazyload must be disabled.
+const BAM_ONLY_VISIBLE = (process.env.BAM_ONLY_VISIBLE && (process.env.BAM_ONLY_VISIBLE === true || process.env.BAM_ONLY_VISIBLE === 'true'));
+const onlyVisible = (!BAM_LAZYLOAD_ENABLED && BAM_ONLY_VISIBLE)
   ? { mobileScaling: 2.0, renderMarginPercent: 200 }
   : false;
 
 module.exports = ({
   networkId: 7652,
   onlyVisible,
+  lazyload: {
+    enabled: BAM_LAZYLOAD_ENABLED,
+    offset: '10%',
+  },
   zones: {
     billboard: {
       zoneIdSizeMapping: [

--- a/sites/woodfloorbusiness.com/config/bam.js
+++ b/sites/woodfloorbusiness.com/config/bam.js
@@ -1,10 +1,19 @@
-const onlyVisible = (process.env.BAM_ONLY_VISIBLE && (process.env.BAM_ONLY_VISIBLE === true || process.env.BAM_ONLY_VISIBLE === 'true'))
+// Our version of layzyload
+const BAM_LAZYLOAD_ENABLED = (process.env.BAM_LAZYLOAD_ENABLED && (process.env.BAM_LAZYLOAD_ENABLED === true || process.env.BAM_LAZYLOAD_ENABLED === 'true'));
+// Their version of lazyload...
+// In order to enable our version of lazyload must be disabled.
+const BAM_ONLY_VISIBLE = (process.env.BAM_ONLY_VISIBLE && (process.env.BAM_ONLY_VISIBLE === true || process.env.BAM_ONLY_VISIBLE === 'true'));
+const onlyVisible = (!BAM_LAZYLOAD_ENABLED && BAM_ONLY_VISIBLE)
   ? { mobileScaling: 2.0, renderMarginPercent: 200 }
   : false;
 
 module.exports = ({
   networkId: 7652,
   onlyVisible,
+  lazyload: {
+    enabled: BAM_LAZYLOAD_ENABLED,
+    offset: '10%',
+  },
   zones: {
     billboard: {
       zoneIdSizeMapping: [


### PR DESCRIPTION
Add our own version of lazyload ad injection to prevent the broadstreet ad version from breaking our pages.  At the moment it will trigger the placement of the broadstreet-zone html element when the wrapper is 10% below the bottom of the screen.

This allows for lazyload to be set from the bam config at the moment. We can possible add support for individual ad slot lazyloading.

At the moment if nothing is set in env variables it will use our own version of lazyload ads. Meaning only placing the broadstreet ad call when it becomes inview.  With the following envs `BAM_ONLY_VISIBLE=true` &`BAM_LAZYLOAD_ENABLED=false` you can get it to use the Broadstreat version called onlyVisible.