### PR TITLE
Revise the Products page to support Broadstreet Ads

### DIFF
--- a/packages/global/components/layouts/website-section/products.marko
+++ b/packages/global/components/layouts/website-section/products.marko
@@ -1,4 +1,5 @@
 import { getAsArray } from "@parameter1/base-cms-object-path";
+import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/latest-products-feed-block"
 
 $ const { id, alias, name, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
@@ -44,9 +45,27 @@ $ const perPage = 10;
           <marko-web-website-section-name tag="h1" block-name=blockName obj=section />
         </else>
 
-        <theme-latest-products-feed-block alias=alias>
-          <@query-params limit=perPage skip=p.skip({ perPage }) />
-        </theme-latest-products-feed-block>
+        $ const queryParams = {
+          limit: perPage,
+          skip: p.skip({ perPage }),
+          sectionAlias: alias,
+          queryFragment,
+        };
+        <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
+          <marko-web-node-list
+            inner-justified=false
+            flush-x=true
+            flush-y=false
+            modifiers=["latest-products-feed"]
+          >
+            <@nodes nodes=nodes>
+              <@slot|{ node }|>
+                <theme-product-feed-content-node node=node />
+              </@slot>
+            </@nodes>
+          </marko-web-node-list>
+        </marko-web-query>
+
         <theme-latest-products-feed-block|{ totalCount }| alias=alias count-only=true>
           <theme-pagination-controls
             per-page=perPage

--- a/packages/global/components/layouts/website-section/products.marko
+++ b/packages/global/components/layouts/website-section/products.marko
@@ -34,17 +34,8 @@ $ const perPage = 10;
 
   <@section|{ blockName, section, aliases }|>
     <div class="row">
-      <div class="col-lg-8">
-        <if(alias === 'gear')>
-          <div class="row">
-            <global-sponsored-section-name-logo section=section modifiers=["section-page"] class="col-lg-5" />
-            <global-sponsored-label-logo logo-label="Sponsored by RoadPro" prefix="Presented By" modifiers=["section-page"] class="col-lg-7" />
-          </div>
-        </if>
-        <else>
-          <marko-web-website-section-name tag="h1" block-name=blockName obj=section />
-        </else>
-
+      <div class="col">
+        <marko-web-website-section-name tag="h1" block-name=blockName obj=section />
         $ const queryParams = {
           limit: perPage,
           skip: p.skip({ perPage }),
@@ -62,6 +53,15 @@ $ const perPage = 10;
               <@slot|{ node }|>
                 <theme-product-feed-content-node node=node />
               </@slot>
+            <@slot position="after" index=2 modifiers=["ad"]>
+              <marko-web-broadstreet-zone zone-alias="rotation" modifiers=["rotation", "section_page", "inter-block"]  />
+            </@slot>
+            <@slot position="after" index=5 modifiers=["ad"]>
+              <marko-web-broadstreet-zone zone-alias="rotation" modifiers=["rotation", "section_page", "inter-block"]  />
+            </@slot>
+            <@slot position="after" index=8 modifiers=["ad"]>
+              <marko-web-broadstreet-zone zone-alias="rotation" modifiers=["rotation", "section_page", "inter-block"]  />
+            </@slot>
             </@nodes>
           </marko-web-node-list>
         </marko-web-query>
@@ -73,13 +73,6 @@ $ const perPage = 10;
             path=alias
           />
         </theme-latest-products-feed-block>
-      </div>
-      <div class="col-lg-4 pt-block">
-        <${input.railSlotA}
-          block-name=blockName
-          section=section
-          aliases=aliases
-        />
       </div>
     </div>
   </@section>


### PR DESCRIPTION
In the wake of the issues defined in https://github.com/parameter1/base-cms/pull/493 rather than utilize the existing component structure (as that likely requires some reworking and discussion as to how to handle these sorts of cases at a lower level), I'm opting to correct this at the point of impass currently by rolling down the necessary component changes to the tenant level and correcting it like so:

![Screenshot from 2022-11-21 12-23-28](https://user-images.githubusercontent.com/46794001/203131467-a63d302d-c89d-41c0-b73b-1a701a0a4165.png)
