### PR TITLE
Adjust sponsored by logo params and css

### DIFF
--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -53,11 +53,14 @@
     }
   }
 }
-
-.sponsor-logo {
-  $self: &;
-  &__logo {
-    height: 25px;
+.page-wrapper__section--nativex-story-header {
+  .sponsor-logo {
+    $self: &;
+    flex-direction: column;
+    align-items: initial;
+    &__logo {
+      height: initial;
+    }
   }
 }
 

--- a/packages/global/templates/content/components/presented-by.marko
+++ b/packages/global/templates/content/components/presented-by.marko
@@ -2,7 +2,7 @@ import { buildImgixUrl } from "@parameter1/base-cms-image";
 import { get } from "@parameter1/base-cms-object-path";
 
 $ const { advertiser } = input;
-$ const imgDefaults = { auto: "format,compress", h: 25, q: 70 };
+$ const imgDefaults = { auto: "format,compress", h: 150, w: 150, q: 70, fit: 'fill' };
 $ const imgSrc = get(advertiser, "logo.src");
 
 <if(imgSrc)>
@@ -12,11 +12,13 @@ $ const imgSrc = get(advertiser, "logo.src");
     <marko-web-element block-name="sponsor-logo" name="label">
       Presented by
     </marko-web-element>
-    <marko-web-img
-      class="sponsor-logo__logo"
-      src=src
-      srcset=srcset
-      alt="Sponsor Logo"
-    />
+    <marko-web-element block-name="sponsor-logo" name="logo">
+      <marko-web-img
+        class="sponsor-logo__logo"
+        src=src
+        srcset=srcset
+        alt="Sponsor Logo"
+      />
+    </marko-web-element>
   </marko-web-block>
 </if>


### PR DESCRIPTION
Allow for the logo to display at a max height or width of 150px.

<img width="1141" alt="Screen Shot 2023-01-09 at 1 54 50 PM" src="https://user-images.githubusercontent.com/3845869/211396274-86094f52-92e6-40a3-ba13-8a89dd50a4a9.png">
<img width="1140" alt="Screen Shot 2023-01-09 at 1 55 01 PM" src="https://user-images.githubusercontent.com/3845869/211396281-ada84b70-2d11-4ebd-afe9-8341cb41ef8d.png">
