### PR TITLE
Add webinars section landing page and missing elements on content landing page

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -126,7 +126,20 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
                 content=content
               />
             </if>
-
+            <if(type === "webinar")>
+              $ const isUpcoming = content.startDate > Date.now();
+              $ const btnLabel = (isUpcoming ? "Register for Webinar" : "View Webinar")
+              <if(content.linkUrl && isUpcoming)>
+                <marko-web-link
+                  class="my-block btn btn-primary btn-lg"
+                  href=content.linkUrl
+                  title=`Register for ${content.name}`
+                  target="_blank"
+                >
+                  ${btnLabel}
+                </marko-web-link>
+              </if>
+            </if>
             $ const sidebars = getAsArray(content, "sidebars").map((sidebar) => sidebar.body);
             <marko-web-content-sidebars block-name=blockName obj={ sidebars } />
             <if(content.transcript)>
@@ -140,21 +153,6 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
           </else>
 
         </marko-web-identity-x-access>
-
-        <if(type === "webinar")>
-          $ const isUpcoming = content.startDate > Date.now();
-          $ const btnLabel = (isUpcoming ? "Register for Webinar" : "View Webinar")
-          <if(content.linkUrl && isUpcoming)>
-            <marko-web-link
-              class="my-block btn btn-primary btn-lg"
-              href=content.linkUrl
-              title=`Register for ${content.name}`
-              target="_blank"
-            >
-              ${btnLabel}
-            </marko-web-link>
-          </if>
-        </if>
 
         <if(type === "document" || type === "whitepaper")>
           <theme-content-download obj=content>

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -111,8 +111,13 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
             />
           </if>
           <else>
-            <content-body-with-injection content=content aliases=aliases block-name=blockName />
 
+            <if(shouldInjectAds)>
+              <content-body-with-injection content=content aliases=aliases block-name=blockName />
+            </if>
+            <else>
+              <marko-web-content-body block-name=blockName obj=content />
+            </else>
             <!-- needs input -->
             <if(input.afterBody)>
               <${input.afterBody}
@@ -135,6 +140,21 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
           </else>
 
         </marko-web-identity-x-access>
+
+        <if(type === "webinar")>
+          $ const isUpcoming = content.startDate > Date.now();
+          $ const btnLabel = (isUpcoming ? "Register for Webinar" : "View Webinar")
+          <if(content.linkUrl && isUpcoming)>
+            <marko-web-link
+              class="my-block btn btn-primary btn-lg"
+              href=content.linkUrl
+              title=`Register for ${content.name}`
+              target="_blank"
+            >
+              ${btnLabel}
+            </marko-web-link>
+          </if>
+        </if>
 
         <if(type === "document" || type === "whitepaper")>
           <theme-content-download obj=content>
@@ -196,7 +216,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
     />
   </@section>
 
-  <if(showMoreSection)>
+  <if(showMoreSection && type !== 'webinar')>
     $ const perPage = 12;
     $ const moreSectionLimit = 3;
     $ const moreSectionCount = perPage / moreSectionLimit;

--- a/packages/global/components/layouts/website-section/marko.json
+++ b/packages/global/components/layouts/website-section/marko.json
@@ -46,5 +46,15 @@
     "@alias": "string",
     "@name": "string",
     "@page-node": "object"
+  },
+  "<global-website-section-webinars-feed-layout>": {
+    "template": "./webinars-feed.marko",
+    "@sections <section>[]": {},
+    "<before-name>": {},
+    "<after-name>": {},
+    "@id": "number",
+    "@alias": "string",
+    "@name": "string",
+    "@page-node": "object"
   }
 }

--- a/packages/global/components/layouts/website-section/webinars-feed.marko
+++ b/packages/global/components/layouts/website-section/webinars-feed.marko
@@ -1,0 +1,143 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import { getAsArray } from "@parameter1/base-cms-object-path";
+
+$ const { id, alias, name, pageNode } = input;
+$ const sections = getAsArray(input, "sections");
+
+$ const { site, pagination: p, i18n } = out.global;
+$ const continueLabel = i18n("Sign Me Up!");
+$ const loginEmailLabel = i18n("Work Email");
+$ const buttonLabels = { continue: continueLabel };
+$ const perPage = 12;
+$ const now = Date.now();
+
+$ const queryParams = {
+  requiresImage: false,
+  sectionBubbling: false,
+  includeContentTypes: ["Webinar"],
+
+};
+$ const upcomingQueryParams = {
+  ...queryParams,
+  beginningAfter: now,
+  limit: 25,
+  sort: {
+    field: "startDate",
+    order: "asc",
+  },
+};
+$ const archiveQueryParams = {
+  ...queryParams,
+  beginningBefore: now,
+  sort: {
+    field: "startDate",
+    order: "desc",
+  },
+  limit: perPage,
+  skip: p.skip({ perPage })
+};
+
+<!-- Correct queryParams format to send to pagination controls -->
+$ const countQueryParams = {
+  ...queryParams,
+  beginning: {
+    before: now,
+  },
+};
+
+<global-website-section-default-layout
+  id=id
+  alias=alias
+  name=name
+  page-node=pageNode
+>
+  <@head>
+    <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
+      <@query-params ...countQueryParams />
+      <theme-pagination-controls
+        per-page=perPage
+        total-count=totalCount
+        path=alias
+        as-rels=true
+      />
+    </theme-section-feed-block>
+  </@head>
+
+  <@section|{ aliases }| modifiers=["break-container", "first"]>
+    <!-- <theme-gam-define-display-ad
+      name="leaderboard"
+      position="section_page"
+      aliases=aliases
+      modifiers=["inter-block"]
+    /> -->
+  </@section>
+
+  <@section|{ blockName, section, aliases }|>
+    <if(input.beforeName)>
+      <${input.beforeName}
+        aliases=aliases
+        block-name=blockName
+        section=section
+      />
+    </if>
+  </@section>
+  <@section|{ blockName, section, aliases }| modifiers=["webinars"]>
+    <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj=section>
+      <if(p.page > 1)>${value}: Page ${p.page}</if>
+      <else>${value}</else>
+    </marko-web-website-section-name>
+    <marko-web-website-section-description obj=section />
+
+    <if(input.afterName)>
+      <${input.afterName}
+        aliases=aliases
+        block-name=blockName
+        section=section
+      />
+    </if>
+    <if(p.page === 1)>
+      <theme-section-feed-block alias=alias modifiers=["upcoming"]>
+        <@header>
+          Upcoming
+        </@header>
+        <@query-params ...upcomingQueryParams />
+        <@after>
+          <!-- <theme-gam-define-display-ad
+            name="rotation"
+            position="section_page"
+            aliases=aliases
+            modifiers=["inter-block"]
+          /> -->
+        </@after>
+      </theme-section-feed-block>
+    </if>
+    <theme-section-feed-block alias=alias lazyload=false modifiers=["archives"]>
+      <@header>
+        On Demand
+      </@header>
+      <@query-params ...archiveQueryParams />
+    </theme-section-feed-block>
+    <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
+      <@query-params ...countQueryParams />
+      <theme-pagination-controls
+        per-page=perPage
+        total-count=totalCount
+        path=alias
+      />
+    </theme-section-feed-block>
+  </@section>
+
+  <@section>
+    <theme-top-stories-block query-params={ optionName: "Pinned" } />
+  </@section>
+
+  <for|s| of=sections>
+    <@section|{ blockName, section, aliases }| modifiers=s.modifiers>
+      <${s.renderBody}
+        block-name=blockName
+        section=section
+        aliases=aliases
+      />
+    </@section>
+  </for>
+</global-website-section-default-layout>

--- a/packages/global/components/layouts/website-section/webinars-feed.marko
+++ b/packages/global/components/layouts/website-section/webinars-feed.marko
@@ -64,12 +64,11 @@ $ const countQueryParams = {
   </@head>
 
   <@section|{ aliases }| modifiers=["break-container", "first"]>
-    <!-- <theme-gam-define-display-ad
-      name="leaderboard"
+    <global-leaderboard-ad-block
       position="section_page"
       aliases=aliases
-      modifiers=["inter-block"]
-    /> -->
+      modifiers=["inter-block", "combined-leaderboard"]
+    />
   </@section>
 
   <@section|{ blockName, section, aliases }|>
@@ -102,12 +101,7 @@ $ const countQueryParams = {
         </@header>
         <@query-params ...upcomingQueryParams />
         <@after>
-          <!-- <theme-gam-define-display-ad
-            name="rotation"
-            position="section_page"
-            aliases=aliases
-            modifiers=["inter-block"]
-          /> -->
+          <marko-web-broadstreet-zone zone-alias="rotation" modifiers=["rotation", "section_page", "inter-block"] />
         </@after>
       </theme-section-feed-block>
     </if>

--- a/packages/global/templates/website-section/webinars.marko
+++ b/packages/global/templates/website-section/webinars.marko
@@ -1,0 +1,8 @@
+$ const { id, alias, name, pageNode } = input;
+
+<global-website-section-webinars-feed-layout
+  id=id
+  alias=alias
+  name=name
+  page-node=pageNode
+/>

--- a/sites/athleticbusiness.com/server/routes/website-section.js
+++ b/sites/athleticbusiness.com/server/routes/website-section.js
@@ -1,11 +1,20 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const leadersFragment = require('@ab-media/package-global/graphql/fragments/leaders-section');
+const webinars = require('@ab-media/package-global/templates/website-section/webinars');
 const leaders = require('../templates/website-section/leaders');
 const products = require('../templates/website-section/products');
 const section = require('../templates/website-section');
 
 module.exports = (app) => {
+  app.get('/:alias(event/webinars-workshops)', withWebsiteSection({
+    template: webinars,
+    queryFragment,
+  }));
+  app.get('/:alias(multimedia/webinars-workshops)', withWebsiteSection({
+    template: webinars,
+    queryFragment,
+  }));
   app.get('/:alias(leaders)', withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,


### PR DESCRIPTION
Add section page the will pull upcoming to the top & a paginated list of past webinars below that. 

![_ab-webinar-archived](https://user-images.githubusercontent.com/3845869/211879379-648d89fe-2d2b-495f-b77c-95e7c8af201d.jpg)
![_ab-webinar-gated](https://user-images.githubusercontent.com/3845869/211879395-3fd35ea9-c406-41ae-ae8e-12f3765d880a.jpg)
![_ab-webinar-upcoming](https://user-images.githubusercontent.com/3845869/211879398-59f5d6f5-4ba6-4e86-9f0f-26c0acea694d.jpg)
