### PR TITLE
Add button to Architectual Showcase page

### DIFF
--- a/sites/athleticbusiness.com/server/templates/project-galleries/gallery.marko
+++ b/sites/athleticbusiness.com/server/templates/project-galleries/gallery.marko
@@ -42,6 +42,11 @@ $ const aliases = [gallery.primarySection.alias, gallery.primarySection.alias.sp
             <theme-content-page-breadcrumbs section=gallery.primarySection display-self=false />
             <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj=gallery />
           </if>
+          <marko-web-element name="button-wrapper">
+            <marko-web-link href="/architectural-showcase/article/15306248/2023-architectural-showcase-submissions-now-open" title="Submit Showcase" class="btn btn-primary">
+              2023 Architectural Showcase Submissions Now Open
+            </marko-web-link>
+          </marko-web-element>
           <marko-web-node-list
             inner-justified=true
             flush-x=true


### PR DESCRIPTION
<img width="812" alt="Screen Shot 2023-02-04 at 9 47 59 AM" src="https://user-images.githubusercontent.com/64623209/216776791-1ff3c35a-4dbe-41ab-81c1-239d7d9d4369.png">
